### PR TITLE
include VCF Header info in output from VCFRecordReader

### DIFF
--- a/src/main/java/org/seqdoop/hadoop_bam/VCFRecordReader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/VCFRecordReader.java
@@ -62,6 +62,8 @@ public class VCFRecordReader
     private AsciiLineReaderIterator it;
     private AsciiLineReader reader;
 
+    private VCFHeader header;
+
 	private long length;
 
 	private final Map<String,Integer> contigDict =
@@ -86,7 +88,7 @@ public class VCFRecordReader
 		if (!(h instanceof FeatureCodecHeader) || !(((FeatureCodecHeader)h).getHeaderValue() instanceof VCFHeader))
 			throw new IOException("No VCF header found in "+ file);
 
-        final VCFHeader header = (VCFHeader)((FeatureCodecHeader)h).getHeaderValue();
+        header = (VCFHeader)((FeatureCodecHeader)h).getHeaderValue();
 
         contigDict.clear();
 		int i = 0;
@@ -135,7 +137,7 @@ public class VCFRecordReader
 			chromIdx = (int)MurmurHash3.murmurhash3(v.getChr(), 0);
 
 		key.set((long)chromIdx << 32 | (long)(v.getStart() - 1));
-		vc.set(v);
+		vc.set(v, header);
 		return true;
 	}
 }


### PR DESCRIPTION
This fixes an issue where it is impossible to access information contained in the VCF header within Map/Reduce methods because the VCFRecordReader does not set the header information on the VCFContextWritables that it produces.
The VCFRecordReader class does read the header (and throws an error if it is not present) because it needs it to deal with contigs. Passing the information out is a very simple change.