### PR TITLE
Upgrade to htsjdk 1.131 for Java 8 support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <java.version>1.6</java.version>
-        <htsjdk.version>1.118</htsjdk.version>
+        <htsjdk.version>1.131</htsjdk.version>
         <!-- CHANGE THIS FOR A DIFFERENT VERSION OF HADOOP -->
         <hadoop.version>1.2.1</hadoop.version>
         <!--
@@ -263,7 +263,7 @@
             <version>2.4</version>
         </dependency>
         <dependency>
-            <groupId>org.seqdoop</groupId>
+            <groupId>com.github.samtools</groupId>
             <artifactId>htsjdk</artifactId>
             <version>${htsjdk.version}</version>
             <exclusions>

--- a/src/main/java/org/seqdoop/hadoop_bam/VariantContextCodec.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/VariantContextCodec.java
@@ -75,7 +75,7 @@ public final class VariantContextCodec {
                 builder.append(VCFConstants.FIELD_SEPARATOR);
                 builder.append(genotypeFormatString);
 
-                final VCFEncoder encoder = new VCFEncoder(header, true);
+                final VCFEncoder encoder = new VCFEncoder(header, true, false);
                 final Map<Allele, String> alleleStrings = encoder.buildAlleleStrings(vc);
                 encoder.addGenotypeData(vc, alleleStrings, genotypeAttributeKeys, builder);
             }


### PR DESCRIPTION
This change should mean that the seqdoop htsjdk fork is no longer needed.