### PR TITLE
Generic output stream for {Fastq,Qseq}OutputFormat

### DIFF
--- a/src/main/java/org/seqdoop/hadoop_bam/FastqOutputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/FastqOutputFormat.java
@@ -74,7 +74,7 @@ public class FastqOutputFormat extends TextOutputFormat<Text, SequencedFragment>
 		protected OutputStream        out;
 		protected BaseQualityEncoding baseQualityFormat;
 
-    public FastqRecordWriter(Configuration conf, OutputStream out)
+		public FastqRecordWriter(Configuration conf, OutputStream out)
 		{
 			this.out = out;
 			setConf(conf);
@@ -98,7 +98,7 @@ public class FastqOutputFormat extends TextOutputFormat<Text, SequencedFragment>
 
 			sBuilder.append( seq.getInstrument() == null ? "" : seq.getInstrument() ).append(delim);
 			sBuilder.append( seq.getRunNumber()  == null ? "" : seq.getRunNumber().toString() ).append(delim);
-			sBuilder.append( seq.getFlowcellId()  == null ? "" : seq.getFlowcellId() ).append(delim);
+			sBuilder.append( seq.getFlowcellId() == null ? "" : seq.getFlowcellId() ).append(delim);
 			sBuilder.append( seq.getLane()       == null ? "" : seq.getLane().toString() ).append(delim);
 			sBuilder.append( seq.getTile()       == null ? "" : seq.getTile().toString() ).append(delim);
 			sBuilder.append( seq.getXpos()       == null ? "" : seq.getXpos().toString() ).append(delim);
@@ -116,7 +116,7 @@ public class FastqOutputFormat extends TextOutputFormat<Text, SequencedFragment>
 			return sBuilder.toString();
 		}
 
-    public void write(Text key, SequencedFragment seq) throws IOException
+		public void write(Text key, SequencedFragment seq) throws IOException
 		{
 			// write the id line
 			out.write('@');
@@ -144,15 +144,15 @@ public class FastqOutputFormat extends TextOutputFormat<Text, SequencedFragment>
 
 			// and the final newline
 			out.write('\n');
-    }
+		}
 
-    public void close(TaskAttemptContext task) throws IOException
+		public void close(TaskAttemptContext task) throws IOException
 		{
-      out.close();
-    }
+			out.close();
+		}
   }
 
-  public RecordWriter<Text,SequencedFragment> getRecordWriter(TaskAttemptContext task)
+	public RecordWriter<Text,SequencedFragment> getRecordWriter(TaskAttemptContext task)
 	  throws IOException
 	{
 		Configuration conf = ContextUtil.getConfiguration(task);

--- a/src/main/java/org/seqdoop/hadoop_bam/FastqOutputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/FastqOutputFormat.java
@@ -25,6 +25,7 @@ package org.seqdoop.hadoop_bam;
 import hbparquet.hadoop.util.ContextUtil;
 
 import java.io.DataOutputStream;
+import java.io.OutputStream;
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
@@ -55,16 +56,25 @@ public class FastqOutputFormat extends TextOutputFormat<Text, SequencedFragment>
 	public static final String CONF_BASE_QUALITY_ENCODING         = "hbam.fastq-output.base-quality-encoding";
 	public static final String CONF_BASE_QUALITY_ENCODING_DEFAULT = "sanger";
 
+	protected static final byte[] PLUS_LINE;
+	static {
+		try {
+			PLUS_LINE = "\n+\n".getBytes("us-ascii");
+		} catch (java.io.UnsupportedEncodingException e) {
+			throw new RuntimeException("us-ascii encoding not supported!");
+		}
+	}
+
 	protected BaseQualityEncoding baseQualityFormat = BaseQualityEncoding.Sanger;
 
 	public static class FastqRecordWriter extends RecordWriter<Text,SequencedFragment>
 	{
 		protected StringBuilder       sBuilder          = new StringBuilder(800);
 		protected Text                buffer            = new Text();
-		protected DataOutputStream    out;
+		protected OutputStream        out;
 		protected BaseQualityEncoding baseQualityFormat;
 
-    public FastqRecordWriter(Configuration conf, DataOutputStream out)
+    public FastqRecordWriter(Configuration conf, OutputStream out)
 		{
 			this.out = out;
 			setConf(conf);
@@ -109,16 +119,16 @@ public class FastqOutputFormat extends TextOutputFormat<Text, SequencedFragment>
     public void write(Text key, SequencedFragment seq) throws IOException
 		{
 			// write the id line
-			out.writeByte('@');
+			out.write('@');
 			if (key != null)
 				out.write(key.getBytes(), 0, key.getLength());
 			else
-				out.writeBytes(makeId(seq));
-			out.writeByte('\n');
+				out.write(makeId(seq).getBytes());
+			out.write('\n');
 
 			// write the sequence and separator
 			out.write(seq.getSequence().getBytes(), 0, seq.getSequence().getLength());
-			out.writeBytes("\n+\n");
+			out.write(PLUS_LINE);
 
 			// now the quality
 			if (baseQualityFormat == BaseQualityEncoding.Sanger)
@@ -133,7 +143,7 @@ public class FastqOutputFormat extends TextOutputFormat<Text, SequencedFragment>
 				throw new RuntimeException("FastqOutputFormat: unknown base quality format " + baseQualityFormat);
 
 			// and the final newline
-			out.writeByte('\n');
+			out.write('\n');
     }
 
     public void close(TaskAttemptContext task) throws IOException
@@ -161,7 +171,7 @@ public class FastqOutputFormat extends TextOutputFormat<Text, SequencedFragment>
 		Path file = getDefaultWorkFile(task, extension);
 		FileSystem fs = file.getFileSystem(conf);
 
-		DataOutputStream output;
+		OutputStream output;
 
 		if (isCompressed)
 		{

--- a/src/main/java/org/seqdoop/hadoop_bam/QseqOutputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/QseqOutputFormat.java
@@ -25,6 +25,7 @@ package org.seqdoop.hadoop_bam;
 import hbparquet.hadoop.util.ContextUtil;
 
 import java.io.DataOutputStream;
+import java.io.OutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
@@ -68,17 +69,17 @@ public class QseqOutputFormat extends TextOutputFormat<Text, SequencedFragment>
     protected static final String delim = "\t";
 		static {
 			try {
-				newLine = "\n".getBytes("UTF-8");
+				newLine = "\n".getBytes("us-ascii");
 			} catch (java.io.UnsupportedEncodingException e) {
-				throw new RuntimeException("UTF-8 enconding not supported!");
+				throw new RuntimeException("us-ascii encoding not supported!");
 			}
 		}
 
 		protected StringBuilder sBuilder = new StringBuilder(800);
-		protected DataOutputStream out;
+		protected OutputStream out;
 		BaseQualityEncoding baseQualityFormat;
 
-    public QseqRecordWriter(Configuration conf, DataOutputStream out)
+    public QseqRecordWriter(Configuration conf, OutputStream out)
 		{
 			baseQualityFormat = BaseQualityEncoding.Illumina;
 			this.out = out;
@@ -183,7 +184,7 @@ public class QseqOutputFormat extends TextOutputFormat<Text, SequencedFragment>
 		Path file = getDefaultWorkFile(task, extension);
 		FileSystem fs = file.getFileSystem(conf);
 
-		DataOutputStream output;
+		OutputStream output;
 
 		if (isCompressed)
 		{

--- a/src/main/java/org/seqdoop/hadoop_bam/QseqOutputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/QseqOutputFormat.java
@@ -65,8 +65,8 @@ public class QseqOutputFormat extends TextOutputFormat<Text, SequencedFragment>
 
 	public static class QseqRecordWriter extends RecordWriter<Text,SequencedFragment>
 	{
-    protected static final byte[] newLine;
-    protected static final String delim = "\t";
+		protected static final byte[] newLine;
+		protected static final String delim = "\t";
 		static {
 			try {
 				newLine = "\n".getBytes("us-ascii");
@@ -79,7 +79,7 @@ public class QseqOutputFormat extends TextOutputFormat<Text, SequencedFragment>
 		protected OutputStream out;
 		BaseQualityEncoding baseQualityFormat;
 
-    public QseqRecordWriter(Configuration conf, OutputStream out)
+		public QseqRecordWriter(Configuration conf, OutputStream out)
 		{
 			baseQualityFormat = BaseQualityEncoding.Illumina;
 			this.out = out;
@@ -97,7 +97,7 @@ public class QseqOutputFormat extends TextOutputFormat<Text, SequencedFragment>
 				throw new RuntimeException("Invalid property value '" + setting + "' for " + CONF_BASE_QUALITY_ENCODING + ".  Valid values are 'illumina' or 'sanger'");
 		}
 
-    public void write(Text ignored_key, SequencedFragment seq) throws IOException
+		public void write(Text ignored_key, SequencedFragment seq) throws IOException
 		{
 			sBuilder.delete(0, sBuilder.length()); // clear
 
@@ -147,7 +147,6 @@ public class QseqOutputFormat extends TextOutputFormat<Text, SequencedFragment>
 			}
 			sBuilder.append(delim);
 			/////////
-
 			sBuilder.append((seq.getFilterPassed() == null || seq.getFilterPassed() ) ? 1 : 0);
 
 			try {
@@ -156,16 +155,16 @@ public class QseqOutputFormat extends TextOutputFormat<Text, SequencedFragment>
 			} catch (java.nio.charset.CharacterCodingException e) {
 				throw new RuntimeException("Error encoding qseq record: " + seq);
 			}
-      out.write(newLine, 0, newLine.length);
-    }
+			out.write(newLine, 0, newLine.length);
+		}
 
-    public void close(TaskAttemptContext context) throws IOException
+		public void close(TaskAttemptContext context) throws IOException
 		{
-      out.close();
-    }
-  }
+			out.close();
+		}
+	}
 
-  public RecordWriter<Text,SequencedFragment> getRecordWriter(TaskAttemptContext task)
+	public RecordWriter<Text,SequencedFragment> getRecordWriter(TaskAttemptContext task)
 	  throws IOException
 	{
 		Configuration conf = ContextUtil.getConfiguration(task);


### PR DESCRIPTION
This pull request changes the Fastq and Qseq output format classes to require an `OutputStream` object rather than a `DataOutputStream` (which wasn't really needed).  The more general output type makes the code more re-usable and easier to test.