### PR TITLE
Update HTSJDK and Hadoop versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <java.version>1.6</java.version>
         <htsjdk.version>1.133</htsjdk.version>
         <!-- CHANGE THIS FOR A DIFFERENT VERSION OF HADOOP -->
-        <hadoop.version>1.2.1</hadoop.version>
+        <hadoop.version>2.2.0</hadoop.version>
         <!--
         Below you'll find some example hadoop.version tags.  The value you set
         must have a corresponding version in one of the repositories that are

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <java.version>1.6</java.version>
-        <htsjdk.version>1.131</htsjdk.version>
+        <htsjdk.version>1.133</htsjdk.version>
         <!-- CHANGE THIS FOR A DIFFERENT VERSION OF HADOOP -->
         <hadoop.version>1.2.1</hadoop.version>
         <!--


### PR DESCRIPTION
This PR contains two small changes. One is probably non-controversial but needs to be validated, the other is a bit more controversial:

* *Update HTSJDK to 1.133:* This HTSJDK version officially adds CRAM support. In ADAM, we've tried shading the transient dependency on HTSJDK out of Hadoop-BAM 7.0.0 and depending explicitly on HTSJDK 1.133, but this leads to split picking errors for some files. I'm not sure if the split picking issues are caused by us being on an old Hadoop-BAM version and doing funny shading, or by upgrading to HTSJDK 1.133, but I'm trying to set up regression tests to figure that out.
* *Update Hadoop to 2.2.0:* We had a long discussion recently with a variety of folks who are fairly adamant that Hadoop 1.x support is going out of style pretty fast. Most interest in ADAM seems to come from people who are on CDH5, so we're thinking of dropping official Hadoop 1.x support (long story short, it is difficult to _confidently_ support Hadoop 1.x and 2.x for Spark 1.3.1 and onwards because of packaging issues). I'm not sure how the rest of folks who depend on Hadoop-BAM feel about moving official support to Hadoop 2.x, but we'd like Hadoop-BAM to be packaged for Hadoop 2.x by default.