### PR TITLE
Add FileVirtualSplit#toString to faciliate debugging.

### DIFF
--- a/src/main/java/org/seqdoop/hadoop_bam/FileVirtualSplit.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/FileVirtualSplit.java
@@ -89,4 +89,7 @@ public class FileVirtualSplit extends InputSplit implements Writable {
 		vStart = in.readLong();
 		vEnd   = in.readLong();
 	}
+
+	@Override
+	public String toString() { return file + ":" + vStart + "-" + vEnd; }
 }


### PR DESCRIPTION
Trivial change to make it easier to find problematic splits on a cluster.