### PR TITLE
bump htsjdk to 2.0.0 for better cram support. Pass validation stringency to CRAMRecordReader. Java8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk7
-  - openjdk6

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <url>http://sourceforge.net/projects/hadoop-bam/</url>
 
     <properties>
-        <java.version>1.6</java.version>
+        <java.version>1.8</java.version>
         <htsjdk.version>2.0.0</htsjdk.version>
         <!-- CHANGE THIS FOR A DIFFERENT VERSION OF HADOOP -->
         <hadoop.version>2.2.0</hadoop.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <java.version>1.6</java.version>
-        <htsjdk.version>1.140</htsjdk.version>
+        <htsjdk.version>2.0.0</htsjdk.version>
         <!-- CHANGE THIS FOR A DIFFERENT VERSION OF HADOOP -->
         <hadoop.version>2.2.0</hadoop.version>
         <!--

--- a/src/main/java/org/seqdoop/hadoop_bam/CRAMInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/CRAMInputFormat.java
@@ -3,11 +3,6 @@ package org.seqdoop.hadoop_bam;
 import hbparquet.hadoop.util.ContextUtil;
 import htsjdk.samtools.cram.build.CramContainerIterator;
 import htsjdk.samtools.seekablestream.SeekableStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
@@ -19,7 +14,16 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.seqdoop.hadoop_bam.util.WrapSeekable;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 public class CRAMInputFormat extends FileInputFormat<LongWritable, SAMRecordWritable> {
+
+  public static final String VALIDATION_STRIGENCY =
+          "hadoopbam.cram.validation-stringency";
 
   public static final String REFERENCE_SOURCE_PATH_PROPERTY =
       "hadoopbam.cram.reference-source-path";

--- a/src/main/java/org/seqdoop/hadoop_bam/CRAMRecordReader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/CRAMRecordReader.java
@@ -3,10 +3,9 @@ package org.seqdoop.hadoop_bam;
 import hbparquet.hadoop.util.ContextUtil;
 import htsjdk.samtools.CRAMIterator;
 import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.seekablestream.SeekableStream;
-import java.io.File;
-import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
@@ -15,6 +14,9 @@ import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.seqdoop.hadoop_bam.util.WrapSeekable;
+
+import java.io.File;
+import java.io.IOException;
 
 public class CRAMRecordReader extends RecordReader<LongWritable, SAMRecordWritable> {
 
@@ -48,7 +50,10 @@ public class CRAMRecordReader extends RecordReader<LongWritable, SAMRecordWritab
     // CRAMIterator right shifts boundaries by 16 so we do the reverse here
     // also subtract one from end since CRAMIterator's boundaries are inclusive
     long[] boundaries = new long[] {start << 16, (end - 1) << 16};
-    cramIterator = new CRAMIterator(seekableStream, refSource, boundaries);
+
+    String validationStringencyString = conf.get(CRAMInputFormat.VALIDATION_STRIGENCY);
+    ValidationStringency validationStringency = validationStringencyString == null ? ValidationStringency.DEFAULT_STRINGENCY : ValidationStringency.valueOf(validationStringencyString);
+    cramIterator = new CRAMIterator(seekableStream, refSource, boundaries, validationStringency);
   }
 
   @Override


### PR DESCRIPTION
in GATK (https://github.com/broadinstitute/gatk), we require htsjdk 2.0.0 for CRAM support. That is incompatible with hadoop-bam because API has changed (requires additional parameter in CRAMRecordReader). This change is to push the htsjdk version to 2.0.0 and fix the API issue. 

Java version needs to move to 8 otherwise blows up because htsjdk is on Java 8. Java 8 is a superior language compared to 1.6 and plays nicely with Spark and is mature/stable now so I think migration should not be a issue.