### PR TITLE
Porting over IndexedBAMInputFormat code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.iml
 maven-metadata-local.xml
 *~
+target

--- a/src/main/java/htsjdk/samtools/PublicBAMFileSpan.java
+++ b/src/main/java/htsjdk/samtools/PublicBAMFileSpan.java
@@ -1,0 +1,38 @@
+// Copyright (c) 2015 Regents of the University of California
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+package htsjdk.samtools;
+
+import htsjdk.samtools.Chunk;
+import java.util.List;
+
+/**
+   NOTE!!!!
+   This is really smelly code!!!!
+   
+   The BAMFileSpan and getChunks method are not public in HTSJDK 1.141.0.
+   Newer releases of HTSJDK make this class and method public.
+ */
+public class PublicBAMFileSpan {
+    
+    public static List<Chunk> getChunks(SAMFileSpan sfs) {
+        return ((BAMFileSpan) sfs).getChunks();
+    }
+}

--- a/src/main/java/htsjdk/samtools/PublicDiskBasedBAMFileIndex.java
+++ b/src/main/java/htsjdk/samtools/PublicDiskBasedBAMFileIndex.java
@@ -1,0 +1,40 @@
+// Copyright (c) 2015 Regents of the University of California
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+package htsjdk.samtools;
+
+import htsjdk.samtools.seekablestream.SeekableStream;
+
+/**
+   NOTE!!!!
+   This is really smelly code!!!!
+   
+   This class is not public in HTSJDK. We have opened a PR
+   to make the class public upstream. Once that is merged and
+   a new release of HTSJDK is cut, this file should be removed.
+ */
+public class PublicDiskBasedBAMFileIndex
+    extends DiskBasedBAMFileIndex {
+
+    public PublicDiskBasedBAMFileIndex(final SeekableStream stream,
+                                final SAMSequenceDictionary dictionary) {
+        super(stream, dictionary);
+    }
+}

--- a/src/main/java/org/seqdoop/hadoop_bam/BAMFilteredRecordReader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMFilteredRecordReader.java
@@ -1,0 +1,151 @@
+// Copyright (c) 2015 Regents of the University of California
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+package org.seqdoop.hadoop_bam;
+
+import hbparquet.hadoop.util.ContextUtil;
+import htsjdk.samtools.BAMRecordCodec;
+import htsjdk.samtools.ValidationStringency;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.BlockCompressedInputStream;
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.seqdoop.hadoop_bam.util.SAMHeaderReader;
+import org.seqdoop.hadoop_bam.util.WrapSeekable;
+
+public class BAMFilteredRecordReader
+    extends BAMRecordReader {
+
+    private static String viewContig;
+    private static int viewStart;
+    private static int viewEnd;
+
+    public static void setRegion(String contig,
+                                 int start,
+                                 int end) {
+        viewContig = contig;
+        viewStart = start;
+        viewEnd = end;
+    }
+
+    private final LongWritable key = new LongWritable();
+    private final SAMRecordWritable record = new SAMRecordWritable();
+    
+    private ValidationStringency stringency;
+    
+    private BlockCompressedInputStream bci;
+    private BAMRecordCodec codec;
+    private long fileStart, virtualEnd;
+    private boolean isInitialized = false;
+    
+    @Override public void initialize(InputSplit spl,
+                                     TaskAttemptContext ctx) 
+        throws IOException {
+        // Check to ensure this method is only be called once (see Hadoop API)
+        if (isInitialized) {
+            close();
+        }
+        isInitialized = true;
+
+        Configuration conf = ContextUtil.getConfiguration(ctx);
+        FileVirtualSplit split = (FileVirtualSplit) spl;
+        Path file = split.getPath();
+        FileSystem fs = file.getFileSystem(conf);
+
+        this.stringency = SAMHeaderReader.getValidationStringency(conf);
+
+        FSDataInputStream in = fs.open(file);
+
+        // Sets codec to translate between in-memory and disk representation of record
+        codec = new BAMRecordCodec(SAMHeaderReader.readSAMHeaderFrom(in, conf));
+        
+        in.seek(0);
+
+        bci = new BlockCompressedInputStream(new WrapSeekable<FSDataInputStream>(in,
+                                                                                 fs.getFileStatus(file).getLen(),
+                                                                                 file));
+
+        // Gets BGZF virtual offset for the split
+        long virtualStart = split.getStartVirtualOffset();
+
+        fileStart = virtualStart >>> 16;
+        virtualEnd = split.getEndVirtualOffset();
+
+        // Starts looking from the BGZF virtual offset
+        bci.seek(virtualStart);
+        // Reads records from this input stream
+        codec.setInputStream(bci);
+    }
+    
+    @Override public void close() throws IOException {
+        bci.close();
+    }
+
+    @Override public LongWritable getCurrentKey() {
+        return key;
+    }
+
+    @Override public SAMRecordWritable getCurrentValue() {
+        return record;
+    }
+
+    /**
+     * This method gets the nextKeyValue for our RecordReader, but filters by only
+     * returning records within a specified ReferenceRegion.
+     */
+    @Override public boolean nextKeyValue() {
+      while (bci.getFilePointer() < virtualEnd) {
+          SAMRecord r = codec.decode();
+
+          // Since we're reading from a BAMRecordCodec directly we have to set the
+          // validation stringency ourselves.
+          if (this.stringency != null) {
+              r.setValidationStringency(this.stringency);
+          }
+
+          // This if/else block pushes the predicate down onto a BGZIP block that 
+          // the index has said contains data in our specified region.
+          if (r == null) {
+              return false;
+          } else {
+              int start = r.getStart();
+              int end = r.getEnd();
+
+              if ((r.getContig() == viewContig) &&
+                  (((start >= viewStart) && (end <= viewEnd))
+                   || ((start <= viewStart) && (end >= viewStart) && (end <= viewEnd))
+                   || ((end >= viewEnd) && (start >= viewStart) && (start <= viewEnd)))) {
+                  key.set(BAMRecordReader.getKey(r));
+                  record.set(r);
+                  return true;
+              }
+          }
+      }
+      return false;
+  }
+}

--- a/src/main/java/org/seqdoop/hadoop_bam/IndexedBAMInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/IndexedBAMInputFormat.java
@@ -1,0 +1,116 @@
+// Copyright (c) 2015 Regents of the University of California
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+package org.seqdoop.hadoop_bam;
+
+import hbparquet.hadoop.util.ContextUtil;
+import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
+import htsjdk.samtools.SAMFileSpan;
+import htsjdk.samtools.Chunk;
+import htsjdk.samtools.PublicBAMFileSpan;
+import htsjdk.samtools.PublicDiskBasedBAMFileIndex;
+import htsjdk.samtools.SAMSequenceDictionary;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.seqdoop.hadoop_bam.util.WrapSeekable;
+
+public class IndexedBAMInputFormat
+    extends BAMInputFormat {
+
+    private static Path filePath;
+    private static Path indexFilePath;
+    private static String viewContig;
+    private static int viewStart;
+    private static int viewEnd;
+    private static SAMSequenceDictionary dict;
+
+    public static void setVars(Path bamPath,
+                               Path baiPath,
+                               String contig,
+                               int start,
+                               int end,
+                               SAMSequenceDictionary sd) {
+        filePath = bamPath;
+        indexFilePath = baiPath;
+        viewContig = contig;
+        viewStart = start;
+        viewEnd = end;
+        dict = sd;
+    }
+
+    @Override public RecordReader<LongWritable, SAMRecordWritable>
+        createRecordReader(InputSplit split,
+                           TaskAttemptContext ctx) 
+        throws IOException, InterruptedException {
+        RecordReader<LongWritable, SAMRecordWritable> rr = new BAMFilteredRecordReader();
+        BAMFilteredRecordReader.setRegion(viewContig, viewStart, viewEnd);
+        rr.initialize(split, ctx);
+        return rr;
+    }
+
+    @Override public List<InputSplit> getSplits(JobContext job)
+        throws IOException, FileNotFoundException {
+
+        Configuration conf = ContextUtil.getConfiguration(job);
+        FileSystem fs = indexFilePath.getFileSystem(conf);
+
+        if (!fs.exists(indexFilePath)) {
+            throw new java.io.FileNotFoundException("Bam index file not provided");
+        } else {
+            WrapSeekable seekableIdxFile = WrapSeekable.openPath(fs,
+                                                                 indexFilePath);
+
+            // Use index to get the chunks for a specific region, then use them to create InputSplits
+            PublicDiskBasedBAMFileIndex idx = new PublicDiskBasedBAMFileIndex(seekableIdxFile,
+                                                                              dict);
+            int referenceIndex = dict.getSequenceIndex(viewContig);
+
+            // Get the chunks in the region we want (chunks give start and end file pointers into a BAM file)
+            SAMFileSpan sfs = idx.getSpanOverlapping(referenceIndex, viewStart, viewEnd);
+            List<Chunk> regions = PublicBAMFileSpan.getChunks(sfs);
+            Iterator<Chunk> ri = regions.iterator();
+            List<InputSplit> splits = new LinkedList<InputSplit>();
+            while (ri.hasNext()) {          
+                Chunk chunk = ri.next();
+
+                // Create InputSplits from chunks in a given region
+                long start = chunk.getChunkStart();
+                long end = chunk.getChunkEnd();
+                String[] array = new String[0];
+                splits.add(new FileVirtualSplit(filePath, start, end, array));
+            }
+
+            return splits;
+        }
+    }
+}


### PR DESCRIPTION
Resolves #34.

There is some pretty stinky code in here due to class protection issues. Some of these issues are resolved by newer versions of HTSJDK (it seems like the 2.* stream of releases make BAMFileSpan public) or by open PRs (see https://github.com/samtools/htsjdk/pull/413).

Also, this code needs more testing. This is a port of the [Scala version from ADAM](https://github.com/bigdatagenomics/adam/blob/master/adam-core/src/main/java/org/bdgenomics/adam/io/IndexedBamInputFormat.scala), over to Java, but I haven't pulled in unit tests yet. I will try to make a pass back within the next week to get the unit tests in. In the meanwhile, please review this code.