### PR TITLE
Support for writing CRAM.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <htsjdk.version>2.0.1</htsjdk.version>
+        <htsjdk.version>2.1.0</htsjdk.version>
         <!-- CHANGE THIS FOR A DIFFERENT VERSION OF HADOOP -->
         <hadoop.version>2.2.0</hadoop.version>
         <!--

--- a/src/main/java/org/seqdoop/hadoop_bam/CRAMOutputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/CRAMOutputFormat.java
@@ -1,0 +1,10 @@
+package org.seqdoop.hadoop_bam;
+
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+
+/** Currently this only locks down the value type of the {@link
+ * org.apache.hadoop.mapreduce.OutputFormat}: contains no functionality.
+ */
+public abstract class CRAMOutputFormat<K>
+        extends FileOutputFormat<K,SAMRecordWritable>
+{}

--- a/src/main/java/org/seqdoop/hadoop_bam/CRAMRecordWriter.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/CRAMRecordWriter.java
@@ -1,0 +1,118 @@
+package org.seqdoop.hadoop_bam;
+
+
+import hbparquet.hadoop.util.ContextUtil;
+
+import java.io.*;
+import java.net.URI;
+import java.nio.file.Paths;
+
+import htsjdk.samtools.CRAMContainerStreamWriter;
+import htsjdk.samtools.SAMTextHeaderCodec;
+import htsjdk.samtools.cram.ref.ReferenceSource;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
+import htsjdk.samtools.util.StringLineReader;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import org.seqdoop.hadoop_bam.util.SAMHeaderReader;
+
+/** A base {@link RecordWriter} for CRAM records.
+ *
+ * <p>Handles the output stream, writing the header if requested, and provides
+ * the {@link #writeAlignment} function for subclasses.</p>
+ * <p>Note that each file created by this class consists of a fragment of a
+ * complete CRAM file containing only one or more CRAM containers that do not
+ * include a CRAM file header, a SAMFileHeader, or a CRAM EOF container.</p>
+ */
+public abstract class CRAMRecordWriter<K>
+        extends RecordWriter<K,SAMRecordWritable>
+{
+    // generic ID passed to CRAM code for internal error reporting
+    private static final String HADOOP_BAM_PART_ID= "Hadoop-BAM-Part";
+    private OutputStream   origOutput;
+    private CRAMContainerStreamWriter cramContainerStream = null;
+    ReferenceSource refSource = null;
+
+    /** A SAMFileHeader is read from the input Path. */
+    public CRAMRecordWriter(
+            final Path output,
+            final Path input,
+            final boolean writeHeader,
+            final TaskAttemptContext ctx) throws IOException
+    {
+        init(
+                output,
+                SAMHeaderReader.readSAMHeaderFrom(input, ContextUtil.getConfiguration(ctx)),
+                writeHeader, ctx);
+    }
+
+    public CRAMRecordWriter(
+            final Path output, final SAMFileHeader header, final boolean writeHeader,
+            final TaskAttemptContext ctx)
+            throws IOException
+    {
+        init(
+                output.getFileSystem(ContextUtil.getConfiguration(ctx)).create(output),
+                header, writeHeader, ctx);
+    }
+
+    // Working around not being able to call a constructor other than as the
+    // first statement...
+    private void init(
+            final Path output, final SAMFileHeader header, final boolean writeHeader,
+            final TaskAttemptContext ctx)
+            throws IOException
+    {
+        init(
+                output.getFileSystem(ContextUtil.getConfiguration(ctx)).create(output),
+                header, writeHeader, ctx);
+    }
+
+    private void init(
+            final OutputStream output, final SAMFileHeader header, final boolean writeHeader,
+            final TaskAttemptContext ctx)
+            throws IOException
+    {
+        origOutput = output;
+
+        final URI referenceURI = URI.create(
+                ctx.getConfiguration().get(CRAMInputFormat.REFERENCE_SOURCE_PATH_PROPERTY)
+        );
+        refSource = new ReferenceSource(Paths.get(referenceURI));
+
+        // A SAMFileHeader must be supplied at CRAMContainerStreamWriter creation time; if
+        // we don't have one then delay creation until we do
+        if (header != null) {
+            cramContainerStream = new CRAMContainerStreamWriter(
+                    origOutput, null, refSource, header, HADOOP_BAM_PART_ID);
+            if (writeHeader) {
+                this.writeHeader(header);
+            }
+        }
+    }
+
+    @Override public void close(TaskAttemptContext ctx) throws IOException {
+        cramContainerStream.finish(false); // Close, but suppress CRAM EOF container
+        origOutput.close(); // And close the original output.
+    }
+
+    protected void writeAlignment(final SAMRecord rec) {
+        if (null == cramContainerStream) {
+            final SAMFileHeader header = rec.getHeader();
+            if (header == null) {
+                throw new RuntimeException("Cannot write record to CRAM: null header in SAM record");
+            }
+            cramContainerStream = new CRAMContainerStreamWriter(
+                    origOutput, null, refSource, header, HADOOP_BAM_PART_ID);
+        }
+        cramContainerStream.writeAlignment(rec);
+    }
+
+    private void writeHeader(final SAMFileHeader header) {
+        cramContainerStream.writeHeader(header);
+    }
+}

--- a/src/main/java/org/seqdoop/hadoop_bam/KeyIgnoringAnySAMOutputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/KeyIgnoringAnySAMOutputFormat.java
@@ -132,7 +132,11 @@ public class KeyIgnoringAnySAMOutputFormat<K> extends AnySAMOutputFormat<K> {
 
 			case SAM:
 				return new KeyIgnoringSAMRecordWriter<K>(
-					out, header, writeHeader, ctx);
+						out, header, writeHeader, ctx);
+
+			case CRAM:
+				return new KeyIgnoringCRAMRecordWriter<K>(
+						out, header, writeHeader, ctx);
 
 			default: assert false; return null;
 		}

--- a/src/main/java/org/seqdoop/hadoop_bam/KeyIgnoringCRAMOutputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/KeyIgnoringCRAMOutputFormat.java
@@ -1,0 +1,64 @@
+package org.seqdoop.hadoop_bam;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import htsjdk.samtools.SAMFileHeader;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import org.seqdoop.hadoop_bam.util.SAMHeaderReader;
+
+/** Writes only the BAM records, not the key.
+ *
+ * <p>A {@link SAMFileHeader} must be provided via {@link #setSAMHeader} or
+ * {@link #readSAMHeaderFrom} before {@link #getRecordWriter} is called.</p>
+ *
+ * <p>By default, writes the SAM header to the output file(s). This
+ * can be disabled, because in distributed usage one often ends up with (and,
+ * for decent performance, wants to end up with) the output split into multiple
+ * parts, which are easier to concatenate if the header is not present in each
+ * file.</p>
+ */
+public class KeyIgnoringCRAMOutputFormat<K> extends CRAMOutputFormat<K> {
+    protected SAMFileHeader header;
+    private boolean writeHeader = false;
+
+    public KeyIgnoringCRAMOutputFormat() {}
+
+    /** Whether the header will be written or not. */
+    public boolean getWriteHeader()          { return writeHeader; }
+
+    /** Set whether the header will be written or not. */
+    public void    setWriteHeader(boolean b) { writeHeader = b; }
+
+    public SAMFileHeader getSAMHeader() { return header; }
+    public void setSAMHeader(SAMFileHeader header) { this.header = header; }
+
+    public void readSAMHeaderFrom(Path path, Configuration conf)
+            throws IOException
+    {
+        this.header = SAMHeaderReader.readSAMHeaderFrom(path, conf);
+    }
+
+    /** <code>setSAMHeader</code> or <code>readSAMHeaderFrom</code> must have
+     * been called first.
+     */
+    @Override public RecordWriter<K,SAMRecordWritable> getRecordWriter(
+            TaskAttemptContext ctx)
+            throws IOException
+    {
+        return getRecordWriter(ctx, getDefaultWorkFile(ctx, ""));
+    }
+
+    // Allows wrappers to provide their own work file.
+    public RecordWriter<K,SAMRecordWritable> getRecordWriter(
+            TaskAttemptContext ctx, Path out)
+            throws IOException
+    {
+        return new KeyIgnoringCRAMRecordWriter<K>(out, header, writeHeader, ctx);
+    }
+}

--- a/src/main/java/org/seqdoop/hadoop_bam/KeyIgnoringCRAMRecordWriter.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/KeyIgnoringCRAMRecordWriter.java
@@ -1,0 +1,33 @@
+package org.seqdoop.hadoop_bam;
+
+import htsjdk.samtools.SAMFileHeader;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/** A convenience class that you can use as a RecordWriter for CRAM files.
+ *
+ * <p>The write function ignores the key, just outputting the SAMRecord.</p>
+ */
+public class KeyIgnoringCRAMRecordWriter<K> extends CRAMRecordWriter<K> {
+    public KeyIgnoringCRAMRecordWriter(
+            Path output, Path input, boolean writeHeader, TaskAttemptContext ctx)
+            throws IOException
+    {
+        super(output, input, writeHeader, ctx);
+    }
+
+    public KeyIgnoringCRAMRecordWriter(
+            Path output, SAMFileHeader header, boolean writeHeader,
+            TaskAttemptContext ctx)
+            throws IOException
+    {
+        super(output, header, writeHeader, ctx);
+    }
+
+    @Override public void write(K ignored, SAMRecordWritable rec) {
+        writeAlignment(rec.get());
+    }
+}

--- a/src/test/java/org/seqdoop/hadoop_bam/TestCRAMOutputFormat.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestCRAMOutputFormat.java
@@ -1,0 +1,242 @@
+package org.seqdoop.hadoop_bam;
+
+import hbparquet.hadoop.util.ContextUtil;
+import htsjdk.samtools.*;
+import htsjdk.samtools.cram.ref.ReferenceSource;
+import htsjdk.samtools.seekablestream.SeekableStream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.*;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.junit.Before;
+import org.junit.Test;
+import org.seqdoop.hadoop_bam.util.SAMHeaderReader;
+import org.seqdoop.hadoop_bam.util.SAMOutputPreparer;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class TestCRAMOutputFormat {
+    private String testCRAMFileName;
+    private String testReferenceFileName;
+    private ReferenceSource testReferenceSource;
+
+    private int expectedRecordCount;
+    private SAMFileHeader samFileHeader;
+
+    private TaskAttemptContext taskAttemptContext;
+    private Configuration conf;
+
+    @Before
+    public void setup() throws Exception {
+        conf = new Configuration();
+
+        testCRAMFileName = ClassLoader.getSystemClassLoader().getResource("test.cram").getFile();
+        testReferenceFileName = ClassLoader.getSystemClassLoader().getResource("auxf.fa").getFile();
+        testReferenceSource = new ReferenceSource(Paths.get(testReferenceFileName));
+
+        conf.set("mapred.input.dir", "file://" + testCRAMFileName);
+        conf.set(CRAMInputFormat.REFERENCE_SOURCE_PATH_PROPERTY, "file://" + testReferenceFileName);
+
+        // fetch the SAMFile header from the original input to get the expected count
+        expectedRecordCount = getCRAMRecordCount(testCRAMFileName);
+        samFileHeader = SAMHeaderReader.readSAMHeaderFrom(new Path(testCRAMFileName), conf);
+
+        taskAttemptContext = ContextUtil.newTaskAttemptContext(conf, mock(TaskAttemptID.class));
+    }
+
+    @Test
+    public void testCRAMRecordWriter() throws Exception {
+        final File outFile = File.createTempFile("testCRAMWriter", ".cram");
+        outFile.deleteOnExit();
+        final Path outPath = new Path(outFile.toURI());
+
+        final KeyIgnoringCRAMOutputFormat<NullWritable> cramOut =
+                new KeyIgnoringCRAMOutputFormat<NullWritable>();
+        cramOut.setWriteHeader(false);
+
+        RecordWriter<NullWritable, SAMRecordWritable> rw =
+                cramOut.getRecordWriter(taskAttemptContext, outPath);
+
+        final SamReader samReader = SamReaderFactory.makeDefault()
+                .referenceSequence(new File(testReferenceFileName))
+                .open(new File(testCRAMFileName));
+
+        for (final SAMRecord r : samReader) {
+            final SAMRecordWritable samRW = new SAMRecordWritable();
+            samRW.set(r);
+            rw.write(null, samRW);
+        }
+        samReader.close();
+        rw.close(taskAttemptContext);
+
+        // now verify the container stream
+        final int actualCount = verifyCRAMContainerStream(
+                new File(outFile.getAbsolutePath()),
+                samFileHeader,
+                testReferenceSource);
+
+        assertEquals(expectedRecordCount, actualCount);
+    }
+
+    @Test
+    public void testCRAMOutput() throws Exception {
+        final Path outputPath = doMapReduce(testCRAMFileName);
+        final File containerStreamFile =
+                new File(new File(outputPath.toUri()), "part-m-00000");
+        final int actualCount = verifyCRAMContainerStream(
+                containerStreamFile, samFileHeader, testReferenceSource);
+        assertEquals(expectedRecordCount, actualCount);
+    }
+
+    @Test
+    public void testCRAMRoundTrip() throws Exception {
+        // run a m/r job to write out a cram file
+        Path outputPath = doMapReduce(testCRAMFileName);
+
+        // assemble the output, and write to a temp file
+        File containerStreamFile =
+                new File(new File(outputPath.toUri()), "part-m-00000");
+        final ByteArrayInputStream cramStream = mergeCRAMContainerStream(
+                containerStreamFile,
+                samFileHeader,
+                testReferenceSource);
+        final File outFile = File.createTempFile("testCRAMWriter", ".cram");
+        outFile.deleteOnExit();
+        Files.copy(cramStream, outFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+        // now use the assembled output as m/r input
+        outputPath = doMapReduce(outFile.getAbsolutePath());
+
+        // verify the final output
+        containerStreamFile = new File(new File(outputPath.toUri()), "part-m-00000");
+        final int actualCount = verifyCRAMContainerStream(
+                containerStreamFile,
+                samFileHeader,
+                testReferenceSource);
+        assertEquals(expectedRecordCount, actualCount);
+    }
+
+    private int getCRAMRecordCount(final String cramFileName) {
+        final CRAMFileReader cramReader =
+                new CRAMFileReader(new File(cramFileName),
+                        (File)null,
+                        testReferenceSource);
+        final Iterator<SAMRecord> it = cramReader.getIterator();
+        int recCount = 0;
+        while (it.hasNext()) {
+            final SAMRecord rec = it.next();
+            recCount++;
+        }
+        cramReader.close();
+        return recCount;
+    }
+
+    private Path doMapReduce(final String inputFile) throws Exception {
+        final FileSystem fileSystem = FileSystem.get(conf);
+        final Path inputPath = new Path(inputFile);
+        final Path outputPath = fileSystem.makeQualified(new Path("target/out"));
+        fileSystem.delete(outputPath, true);
+
+        final Job job = Job.getInstance(conf);
+        FileInputFormat.setInputPaths(job, inputPath);
+
+        job.setInputFormatClass(CRAMInputFormat.class);
+        job.setMapOutputKeyClass(LongWritable.class);
+        job.setMapOutputValueClass(SAMRecordWritable.class);
+
+        job.setOutputFormatClass(KeyIgnoringCRAMOutputFormat.class);
+        job.setOutputKeyClass(LongWritable.class);
+        job.setOutputValueClass(SAMRecordWritable.class);
+
+        job.setNumReduceTasks(0);
+        FileOutputFormat.setOutputPath(job, outputPath);
+
+        final boolean success = job.waitForCompletion(true);
+        assertTrue(success);
+
+        return outputPath;
+    }
+
+    private int verifyCRAMContainerStream(
+            final File containerStreamFile,
+            final SAMFileHeader header,
+            final ReferenceSource refSource) throws IOException
+    {
+        // assemble a proper CRAM file from the container stream shard(s) in
+        // order to verify the contents
+        final ByteArrayInputStream mergedStream = mergeCRAMContainerStream (
+            containerStreamFile,
+            header,
+            refSource
+        );
+
+        // now we can verify that we can read everything back in
+        final CRAMFileReader resultCRAMReader = new CRAMFileReader(
+                mergedStream,
+                (SeekableStream) null,
+                refSource,
+                ValidationStringency.DEFAULT_STRINGENCY);
+        final Iterator<SAMRecord> it = resultCRAMReader.getIterator();
+        int actualCount = 0;
+        while (it.hasNext()) {
+            final SAMRecord rec = it.next();
+            actualCount++;
+        }
+        return actualCount;
+    }
+
+    // TODO: SAMOutputPreparer knows how to prepare the beginning of a stream,
+    // but not how to populate or terminate it (which for CRAM requires a special
+    // terminating EOF container). For now we'll use SAMPreparer here so we get
+    // some test coverage, and then manually populate and terminate, but we
+    // should consolidate/refactor the knowledge of how to do this aggregation
+    // for each output type in one place in a separate PR
+    // https://github.com/HadoopGenomics/Hadoop-BAM/issues/61
+    private ByteArrayInputStream mergeCRAMContainerStream(
+            final File containerStreamFile,
+            final SAMFileHeader header,
+            final ReferenceSource refSource) throws IOException
+    {
+        // assemble a proper CRAM file from the container stream shard(s) in
+        // order to verify the contents
+        final ByteArrayOutputStream cramOutputStream = new ByteArrayOutputStream();
+        // write out the cram file header
+        new SAMOutputPreparer().prepareForRecords(
+                cramOutputStream,
+                SAMFormat.CRAM,
+                header);
+
+        // now copy the contents of the container stream shard(s) written out by
+        // the M/R job
+        final ByteArrayOutputStream containerOutputStream = new ByteArrayOutputStream();
+        Files.copy(containerStreamFile.toPath(), containerOutputStream);
+        containerOutputStream.writeTo(cramOutputStream);
+
+        // use containerStreamWriter directly to properly terminate the output
+        // stream with an EOF container
+        final CRAMContainerStreamWriter containerStreamWriter =
+                new CRAMContainerStreamWriter(
+                        cramOutputStream,
+                        null,
+                        refSource,
+                        header,
+                        "CRAMTest");
+        containerStreamWriter.finish(true); // close and write an EOF container
+        cramOutputStream.close();
+
+        return new ByteArrayInputStream(cramOutputStream.toByteArray());
+    }
+
+}

--- a/src/test/java/org/seqdoop/hadoop_bam/TestSAMHeaderReader.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestSAMHeaderReader.java
@@ -51,7 +51,7 @@ public class TestSAMHeaderReader {
     @Test
     public void testCRAMHeaderReaderNoReference() throws Exception {
 
-        thrown.expect(CRAMException.class); // htsjdk throws on CRAM file with no reference provided
+        thrown.expect(IllegalStateException.class); // htsjdk throws on CRAM file with no reference provided
 
         final Configuration conf = new Configuration();
         final InputStream inputStream = ClassLoader.getSystemClassLoader().getResourceAsStream("test.cram");


### PR DESCRIPTION
This PR has two dependencies:

- PR https://github.com/HadoopGenomics/Hadoop-BAM/pull/47 (strictly speaking the dependency is only that the tests have a dependency on the CRAMRecordReader changes in that PR)
- a not-yet-released version of htsjdk (post 2.0.1 - we expect to release this soon) which contains refactored CRAM code used to implement these classes.