### PR TITLE
Fix for CRAM header writing (issue #63).

### DIFF
--- a/src/main/java/org/seqdoop/hadoop_bam/CRAMRecordWriter.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/CRAMRecordWriter.java
@@ -35,7 +35,8 @@ public abstract class CRAMRecordWriter<K>
     private static final String HADOOP_BAM_PART_ID= "Hadoop-BAM-Part";
     private OutputStream   origOutput;
     private CRAMContainerStreamWriter cramContainerStream = null;
-    ReferenceSource refSource = null;
+    private ReferenceSource refSource = null;
+    private boolean writeHeader = true;
 
     /** A SAMFileHeader is read from the input Path. */
     public CRAMRecordWriter(
@@ -78,6 +79,7 @@ public abstract class CRAMRecordWriter<K>
             throws IOException
     {
         origOutput = output;
+        this.writeHeader = writeHeader;
 
         final URI referenceURI = URI.create(
                 ctx.getConfiguration().get(CRAMInputFormat.REFERENCE_SOURCE_PATH_PROPERTY)
@@ -105,6 +107,9 @@ public abstract class CRAMRecordWriter<K>
             final SAMFileHeader header = rec.getHeader();
             if (header == null) {
                 throw new RuntimeException("Cannot write record to CRAM: null header in SAM record");
+            }
+            if (writeHeader) {
+                this.writeHeader(header);
             }
             cramContainerStream = new CRAMContainerStreamWriter(
                     origOutput, null, refSource, header, HADOOP_BAM_PART_ID);

--- a/src/main/java/org/seqdoop/hadoop_bam/KeyIgnoringCRAMOutputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/KeyIgnoringCRAMOutputFormat.java
@@ -25,7 +25,7 @@ import org.seqdoop.hadoop_bam.util.SAMHeaderReader;
  */
 public class KeyIgnoringCRAMOutputFormat<K> extends CRAMOutputFormat<K> {
     protected SAMFileHeader header;
-    private boolean writeHeader = false;
+    private boolean writeHeader = true;
 
     public KeyIgnoringCRAMOutputFormat() {}
 
@@ -43,6 +43,9 @@ public class KeyIgnoringCRAMOutputFormat<K> extends CRAMOutputFormat<K> {
     {
         this.header = SAMHeaderReader.readSAMHeaderFrom(path, conf);
     }
+    public void readSAMHeaderFrom(InputStream in, Configuration conf) {
+        this.header = SAMHeaderReader.readSAMHeaderFrom(in, conf);
+    }
 
     /** <code>setSAMHeader</code> or <code>readSAMHeaderFrom</code> must have
      * been called first.
@@ -59,6 +62,10 @@ public class KeyIgnoringCRAMOutputFormat<K> extends CRAMOutputFormat<K> {
             TaskAttemptContext ctx, Path out)
             throws IOException
     {
+        if (this.header == null)
+            throw new IOException(
+                    "Can't create a RecordWriter without the SAM header");
+
         return new KeyIgnoringCRAMRecordWriter<K>(out, header, writeHeader, ctx);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/HadoopGenomics/Hadoop-BAM/issues/63. CRAM writing worked when the headers were not included in the output, but didn't correctly handle the case where they were. CRAMOutputFormat and CRAMRecordWriter are now symmetric with their BAM counterparts.