### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/hbparquet/hadoop/util/ContextUtil.java
+++ b/src/main/java/hbparquet/hadoop/util/ContextUtil.java
@@ -42,7 +42,11 @@ import org.apache.hadoop.mapreduce.TaskInputOutputContext;
  * Utility methods to allow applications to deal with inconsistencies between
  * MapReduce Context Objects API between hadoop-0.20 and later versions.
  */
-public class ContextUtil {
+public final class ContextUtil {
+
+  private ContextUtil() throws InstantiationException {
+    throw new InstantiationException("Not allowed to instantiate this class");
+  }
 
   private static final boolean useV21;
 

--- a/src/main/java/org/seqdoop/hadoop_bam/cli/Frontend.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/cli/Frontend.java
@@ -44,6 +44,10 @@ public final class Frontend {
 		VERSION_MAJOR = 7,
 		VERSION_MINOR = 0;
 
+	private Frontend() throws InstantiationException {
+		throw new InstantiationException("Not allowed to instantiate this class");
+	}
+
 	public static void main(String[] args) {
 
 		final Thread thread = Thread.currentThread();

--- a/src/main/java/org/seqdoop/hadoop_bam/cli/Utils.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/cli/Utils.java
@@ -53,6 +53,11 @@ import org.seqdoop.hadoop_bam.util.Timer;
 import hbparquet.hadoop.util.ContextUtil;
 
 public final class Utils {
+
+	private Utils() throws InstantiationException{
+		throw new InstantiationException("Not allowed to instantiate this class");
+	}
+
 	public static void printWrapped(PrintStream out, String str) {
 		printWrapped(out, str, 0);
 	}

--- a/src/main/java/org/seqdoop/hadoop_bam/util/ConfHelper.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/ConfHelper.java
@@ -24,8 +24,12 @@ package org.seqdoop.hadoop_bam.util;
 
 import org.apache.hadoop.conf.Configuration;
 
-public class ConfHelper
+public final class ConfHelper
 {
+	private ConfHelper() throws InstantiationException {
+		throw new InstantiationException("Not allowed to instantiate this class");
+	}
+
 	/**
 	 * Convert a string to a boolean.
 	 *

--- a/src/main/java/org/seqdoop/hadoop_bam/util/GetSortedBAMHeader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/GetSortedBAMHeader.java
@@ -33,6 +33,11 @@ import htsjdk.samtools.ValidationStringency;
 import org.seqdoop.hadoop_bam.SAMFormat;
 
 public final class GetSortedBAMHeader {
+
+	private GetSortedBAMHeader() throws InstantiationException {
+		throw new InstantiationException("Not allowed to instantiate this class");
+	}
+
 	public static void main(String[] args) throws IOException {
 		if (args.length < 2) {
 			System.err.println(

--- a/src/main/java/org/seqdoop/hadoop_bam/util/MurmurHash3.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/MurmurHash3.java
@@ -29,6 +29,11 @@ import java.nio.ByteOrder;
  */
 @SuppressWarnings("fallthrough")
 public final class MurmurHash3 {
+
+	private MurmurHash3() throws InstantiationException {
+		throw new InstantiationException("Not allowed to instantiate this class");
+	}
+
 	public static long murmurhash3(byte[] key, int seed) {
 
 		final ByteBuffer data =

--- a/src/main/java/org/seqdoop/hadoop_bam/util/SAMHeaderReader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/SAMHeaderReader.java
@@ -38,6 +38,11 @@ import htsjdk.samtools.ValidationStringency;
 import org.seqdoop.hadoop_bam.CRAMInputFormat;
 
 public final class SAMHeaderReader {
+
+	private SAMHeaderReader() throws InstantiationException {
+		throw new InstantiationException("Not allowed to instantiate this class");
+	}
+
 	/** A String property corresponding to a ValidationStringency
 	 * value. If set, the given stringency is used when any part of the
 	 * Hadoop-BAM library reads SAM or BAM.

--- a/src/main/java/org/seqdoop/hadoop_bam/util/VCFHeaderReader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/VCFHeaderReader.java
@@ -42,6 +42,11 @@ import htsjdk.variant.vcf.VCFHeader;
  * VCF or BCF.
  */
 public final class VCFHeaderReader {
+
+	private VCFHeaderReader() throws InstantiationException {
+		throw new InstantiationException("Not allowed to instantiate this class");
+	}
+
 	public static VCFHeader readHeaderFrom(final SeekableStream in)
 		throws IOException
 	{


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat
