### PR TITLE
Split guesser refactoring and tests

### DIFF
--- a/src/main/java/org/seqdoop/hadoop_bam/BCFSplitGuesser.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BCFSplitGuesser.java
@@ -25,8 +25,6 @@ package org.seqdoop.hadoop_bam;
 import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.Arrays;
 
 import org.apache.hadoop.conf.Configuration;
@@ -50,15 +48,14 @@ import org.seqdoop.hadoop_bam.util.WrapSeekable;
 /** A class for heuristically finding BCF record positions inside an area of
  * a BCF file. Handles both compressed and uncompressed BCF.
  */
-public class BCFSplitGuesser {
+public class BCFSplitGuesser extends BaseSplitGuesser {
 	// cin is the compressed input: a BlockCompressedInputStream for compressed
 	// BCF, otherwise equal to in. Unfortunately the closest common type is then
 	// InputStream, which is why we have the cinSeek() method.
 	private       InputStream    cin;
-	private       SeekableStream inFile, in;
+	private       SeekableStream inFile;
 	private final boolean        bgzf;
 	private final BCF2Codec      bcfCodec = new BCF2Codec();
-	private final ByteBuffer     buf;
 	private final int            contigDictionaryLength, genotypeSampleCount;
 
 	// The amount of data we verify for uncompressed BCF.
@@ -75,10 +72,6 @@ public class BCFSplitGuesser {
 	private final static int BGZF_MAX_BYTES_READ =
 		BGZF_BLOCKS_NEEDED_FOR_GUESS * 0xffff + 0xfffe;
 
-	private final static int BGZF_MAGIC     = 0x04088b1f;
-	private final static int BGZF_MAGIC_SUB = 0x00024342;
-	private final static int BGZF_SUB_SIZE  = 4 + 2;
-
 	// This is probably too conservative.
 	private final static int SHORTEST_POSSIBLE_BCF_RECORD = 4*8 + 1;
 
@@ -93,9 +86,6 @@ public class BCFSplitGuesser {
 		throws IOException
 	{
 		inFile = ss;
-
-		buf = ByteBuffer.allocate(8);
-		buf.order(ByteOrder.LITTLE_ENDIAN);
 
 		InputStream bInFile = new BufferedInputStream(inFile);
 
@@ -281,93 +271,6 @@ public class BCFSplitGuesser {
 		return end;
 	}
 
-	private static class PosSize {
-		public int pos;
-		public int size;
-		public PosSize(int p, int s) { pos = p; size = s; }
-	}
-
-	// Gives the compressed size on the side. Returns null if it doesn't find
-	// anything.
-	private PosSize guessNextBGZFPos(int p, int end) {
-		try { for (;;) {
-			for (;;) {
-				in.seek(p);
-				IOUtils.readFully(in, buf.array(), 0, 4);
-				int n = buf.getInt(0);
-
-				if (n == BGZF_MAGIC)
-					break;
-
-				// Skip ahead a bit more than 1 byte if you can.
-				if (n >>> 8 == BGZF_MAGIC << 8 >>> 8)
-					++p;
-				else if (n >>> 16 == BGZF_MAGIC << 16 >>> 16)
-					p += 2;
-				else
-					p += 3;
-
-				if (p >= end)
-					return null;
-			}
-			// Found what looks like a gzip block header: now get XLEN and
-			// search for the BGZF subfield.
-			final int p0 = p;
-			p += 10;
-			in.seek(p);
-			IOUtils.readFully(in, buf.array(), 0, 2);
-			p += 2;
-			final int xlen   = getUShort(0);
-			final int subEnd = p + xlen;
-
-			while (p < subEnd) {
-				IOUtils.readFully(in, buf.array(), 0, 4);
-
-				if (buf.getInt(0) != BGZF_MAGIC_SUB) {
-					p += 4 + getUShort(2);
-					in.seek(p);
-					continue;
-				}
-
-				// Found it: this is close enough to a BGZF block, make it
-				// our guess.
-
-				// But find out the size before returning. First, grab bsize:
-				// we'll need it later.
-				IOUtils.readFully(in, buf.array(), 0, 2);
-				int bsize = getUShort(0);
-
-				// Then skip the rest of the subfields.
-				p += BGZF_SUB_SIZE;
-				while (p < subEnd) {
-					in.seek(p);
-					IOUtils.readFully(in, buf.array(), 0, 4);
-					p += 4 + getUShort(2);
-				}
-				if (p != subEnd) {
-					// Cancel our guess because the xlen field didn't match the
-					// data.
-					break;
-				}
-
-				// Now skip past the compressed data and the CRC-32.
-				p += bsize - xlen - 19 + 4;
-				in.seek(p);
-				IOUtils.readFully(in, buf.array(), 0, 4);
-				return new PosSize(p0, buf.getInt(0));
-			}
-			// No luck: look for the next gzip block header. Start right after
-			// where we last saw the identifiers, although we could probably
-			// safely skip further ahead. (If we find the correct one right
-			// now, the previous block contained 0x1f8b0804 bytes of data: that
-			// seems... unlikely.)
-			p = p0 + 4;
-
-		}} catch (IOException e) {
-			return null;
-		}
-	}
-
 	private int guessNextBCFPos(long cpVirt, int up, int cSize) {
 		try {
 			for (; up + SHORTEST_POSSIBLE_BCF_RECORD < cSize; ++up) {
@@ -458,9 +361,6 @@ public class BCFSplitGuesser {
 	}
 	private long getUInt(final int idx) {
 		return (long)buf.getInt(idx) & 0xffffffff;
-	}
-	private int getUShort(final int idx) {
-		return (int)buf.getShort(idx) & 0xffff;
 	}
 	private short getUByte(final int idx) {
 		return (short)((short)buf.get(idx) & 0xff);

--- a/src/main/java/org/seqdoop/hadoop_bam/BaseSplitGuesser.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BaseSplitGuesser.java
@@ -1,0 +1,113 @@
+package org.seqdoop.hadoop_bam;
+
+import htsjdk.samtools.seekablestream.SeekableStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.apache.hadoop.io.IOUtils;
+
+class BaseSplitGuesser {
+
+  protected final static int BGZF_MAGIC     = 0x04088b1f;
+  protected final static int BGZF_MAGIC_SUB = 0x00024342;
+  protected final static int BGZF_SUB_SIZE  = 4 + 2;
+
+  protected SeekableStream in;
+  protected final ByteBuffer buf;
+
+  public BaseSplitGuesser() {
+    buf = ByteBuffer.allocate(8);
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  protected static class PosSize {
+    public int pos;
+    public int size;
+    public PosSize(int p, int s) { pos = p; size = s; }
+  }
+
+  // Gives the compressed size on the side. Returns null if it doesn't find
+  // anything.
+  protected PosSize guessNextBGZFPos(int p, int end) {
+    try { for (;;) {
+      for (;;) {
+        in.seek(p);
+        IOUtils.readFully(in, buf.array(), 0, 4);
+        int n = buf.getInt(0);
+
+        if (n == BGZF_MAGIC)
+          break;
+
+        // Skip ahead a bit more than 1 byte if you can.
+        if (n >>> 8 == BGZF_MAGIC << 8 >>> 8)
+          ++p;
+        else if (n >>> 16 == BGZF_MAGIC << 16 >>> 16)
+          p += 2;
+        else
+          p += 3;
+
+        if (p >= end)
+          return null;
+      }
+      // Found what looks like a gzip block header: now get XLEN and
+      // search for the BGZF subfield.
+      final int p0 = p;
+      p += 10;
+      in.seek(p);
+      IOUtils.readFully(in, buf.array(), 0, 2);
+      p += 2;
+      final int xlen   = getUShort(0);
+      final int subEnd = p + xlen;
+
+      while (p < subEnd) {
+        IOUtils.readFully(in, buf.array(), 0, 4);
+
+        if (buf.getInt(0) != BGZF_MAGIC_SUB) {
+          p += 4 + getUShort(2);
+          in.seek(p);
+          continue;
+        }
+
+        // Found it: this is close enough to a BGZF block, make it
+        // our guess.
+
+        // But find out the size before returning. First, grab bsize:
+        // we'll need it later.
+        IOUtils.readFully(in, buf.array(), 0, 2);
+        int bsize = getUShort(0);
+
+        // Then skip the rest of the subfields.
+        p += BGZF_SUB_SIZE;
+        while (p < subEnd) {
+          in.seek(p);
+          IOUtils.readFully(in, buf.array(), 0, 4);
+          p += 4 + getUShort(2);
+        }
+        if (p != subEnd) {
+          // Cancel our guess because the xlen field didn't match the
+          // data.
+          break;
+        }
+
+        // Now skip past the compressed data and the CRC-32.
+        p += bsize - xlen - 19 + 4;
+        in.seek(p);
+        IOUtils.readFully(in, buf.array(), 0, 4);
+        return new PosSize(p0, buf.getInt(0));
+      }
+      // No luck: look for the next gzip block header. Start right after
+      // where we last saw the identifiers, although we could probably
+      // safely skip further ahead. (If we find the correct one right
+      // now, the previous block contained 0x1f8b0804 bytes of data: that
+      // seems... unlikely.)
+      p = p0 + 4;
+
+    }} catch (IOException e) {
+      return null;
+    }
+  }
+
+  protected int getUShort(final int idx) {
+    return (int)buf.getShort(idx) & 0xffff;
+  }
+}

--- a/src/test/java/org/seqdoop/hadoop_bam/TestBGZFSplitGuesser.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestBGZFSplitGuesser.java
@@ -1,0 +1,68 @@
+package org.seqdoop.hadoop_bam;
+
+import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.BlockCompressedStreamConstants;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.seqdoop.hadoop_bam.util.BGZFSplitGuesser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestBGZFSplitGuesser {
+  @Test
+  public void test() throws Exception {
+    File bgzf = File.createTempFile("TestBGZFSplitGuesser", ".bgzf");
+    BlockCompressedOutputStream bgzfOut = new BlockCompressedOutputStream(bgzf);
+    String chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    StringBuilder data = new StringBuilder();
+    Random r = new Random();
+    r.setSeed(100);
+    for (int i = 0; i < 1024 * 150; i++) {
+      char rc = chars.charAt(r.nextInt(chars.length()));
+      bgzfOut.write(rc);
+      data.append(rc);
+    }
+    bgzfOut.close();
+
+    Configuration conf = new Configuration();
+    Path path = new Path(bgzf.toURI());
+    FSDataInputStream fsDataInputStream = path.getFileSystem(conf).open(path);
+    BGZFSplitGuesser bgzfSplitGuesser = new BGZFSplitGuesser(fsDataInputStream);
+    List<Long> boundaries = new ArrayList<>();
+    long start = 1;
+    while (true) {
+      long end = bgzf.length();
+      long nextStart = bgzfSplitGuesser.guessNextBGZFBlockStart(start, end);
+      if (nextStart == end) {
+        break;
+      }
+      boundaries.add(nextStart);
+      start = nextStart + 1;
+    }
+
+    assertEquals(3, boundaries.size());
+
+    for (int i = 0; i < boundaries.size() - 1; i++) {
+      long boundary = boundaries.get(i);
+      BlockCompressedInputStream blockCompressedInputStream = new
+          BlockCompressedInputStream(bgzf);
+      blockCompressedInputStream.setCheckCrcs(true);
+      blockCompressedInputStream.seek(boundary << 16);
+      byte[] b = new byte[5]; // check 5 bytes after boundary
+      blockCompressedInputStream.read(b);
+      assertTrue(data.toString().contains(new String(b)));
+    }
+
+    assertEquals("Last block start is terminator gzip block",
+        bgzf.length() - BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK.length,
+        (long) boundaries.get(boundaries.size() - 1));
+  }
+}


### PR DESCRIPTION
This removes some, but not all, of the split guessing code for BGZF boundaries. BAMSplitGuesser and BCFSplitGuesser now share code (which is already tested). BGZFSplitGuesser does not, but now has a test, which will improve coverage.