### PR TITLE
Deprecate unused utility classes

### DIFF
--- a/src/main/java/org/seqdoop/hadoop_bam/BAMSplitGuesser.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMSplitGuesser.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.SAMUtils;
 import htsjdk.samtools.SamInputResource;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.seekablestream.ByteArraySeekableStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.util.Arrays;
@@ -47,7 +48,6 @@ import htsjdk.samtools.util.RuntimeEOFException;
 import htsjdk.samtools.util.RuntimeIOException;
 
 import org.seqdoop.hadoop_bam.util.SAMHeaderReader;
-import org.seqdoop.hadoop_bam.util.SeekableArrayStream;
 import org.seqdoop.hadoop_bam.util.WrapSeekable;
 
 /** A class for heuristically finding BAM record positions inside an area of
@@ -133,7 +133,7 @@ public class BAMSplitGuesser extends BaseSplitGuesser {
 		}
 		arr = Arrays.copyOf(arr, totalRead);
 
-		this.in = new SeekableArrayStream(arr);
+		this.in = new ByteArraySeekableStream(arr);
 
 		this.bgzf = new BlockCompressedInputStream(this.in);
 		this.bgzf.setCheckCrcs(true);

--- a/src/main/java/org/seqdoop/hadoop_bam/BCFSplitGuesser.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BCFSplitGuesser.java
@@ -22,6 +22,7 @@
 
 package org.seqdoop.hadoop_bam;
 
+import htsjdk.samtools.seekablestream.ByteArraySeekableStream;
 import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.io.IOException;
@@ -40,8 +41,6 @@ import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.readers.PositionalBufferedStream;
 import htsjdk.variant.bcf2.BCF2Codec;
 import htsjdk.variant.vcf.VCFHeader;
-
-import org.seqdoop.hadoop_bam.util.SeekableArrayStream;
 
 import org.seqdoop.hadoop_bam.util.WrapSeekable;
 
@@ -135,7 +134,7 @@ public class BCFSplitGuesser extends BaseSplitGuesser {
 		}
 		arr = Arrays.copyOf(arr, totalRead);
 
-		this.in = new SeekableArrayStream(arr);
+		this.in = new ByteArraySeekableStream(arr);
 
 		final int firstBGZFEnd;
 

--- a/src/main/java/org/seqdoop/hadoop_bam/util/BGZFSplitGuesser.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/BGZFSplitGuesser.java
@@ -22,6 +22,7 @@
 
 package org.seqdoop.hadoop_bam.util;
 
+import htsjdk.samtools.seekablestream.ByteArraySeekableStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -36,7 +37,7 @@ import org.apache.hadoop.fs.Seekable;
 public class BGZFSplitGuesser {
 	private InputStream inFile;
 	private Seekable seekableInFile;
-	private       SeekableArrayStream in;
+	private       ByteArraySeekableStream in;
 	private final ByteBuffer buf;
 
 	private final static int BGZF_MAGIC     = 0x04088b1f;
@@ -78,7 +79,7 @@ public class BGZFSplitGuesser {
 		}
 		arr = Arrays.copyOf(arr, read);
 
-		this.in = new SeekableArrayStream(arr);
+		this.in = new ByteArraySeekableStream(arr);
 
 		final BlockCompressedInputStream bgzf =
 			new BlockCompressedInputStream(this.in);

--- a/src/main/java/org/seqdoop/hadoop_bam/util/Pair.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/Pair.java
@@ -22,6 +22,10 @@
 
 package org.seqdoop.hadoop_bam.util;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class Pair<A,B> {
 	public A fst;
 	public B snd;

--- a/src/main/java/org/seqdoop/hadoop_bam/util/Pair.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/Pair.java
@@ -23,7 +23,7 @@
 package org.seqdoop.hadoop_bam.util;
 
 /**
- * @deprecated
+ * @deprecated This class will be removed in the next major version release (8.0).
  */
 @Deprecated
 public class Pair<A,B> {

--- a/src/main/java/org/seqdoop/hadoop_bam/util/SeekableArrayStream.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/SeekableArrayStream.java
@@ -26,6 +26,10 @@ import java.io.IOException;
 
 import htsjdk.samtools.seekablestream.SeekableStream;
 
+/**
+ * @deprecated Use {@link htsjdk.samtools.seekablestream.ByteArraySeekableStream}
+ */
+@Deprecated
 public class SeekableArrayStream extends SeekableStream {
 	private final byte[] arr;
 	private       int    pos;

--- a/src/main/java/org/seqdoop/hadoop_bam/util/SeekableArrayStream.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/SeekableArrayStream.java
@@ -27,7 +27,8 @@ import java.io.IOException;
 import htsjdk.samtools.seekablestream.SeekableStream;
 
 /**
- * @deprecated Use {@link htsjdk.samtools.seekablestream.ByteArraySeekableStream}
+ * @deprecated Use {@link htsjdk.samtools.seekablestream.ByteArraySeekableStream}.
+ * This class will be removed in the next major version release (8.0).
  */
 @Deprecated
 public class SeekableArrayStream extends SeekableStream {

--- a/src/main/java/org/seqdoop/hadoop_bam/util/Timer.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/Timer.java
@@ -23,7 +23,7 @@
 package org.seqdoop.hadoop_bam.util;
 
 /**
- * @deprecated
+ * @deprecated This class will be removed in the next major version release (8.0).
  */
 @Deprecated
 public class Timer {

--- a/src/main/java/org/seqdoop/hadoop_bam/util/Timer.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/Timer.java
@@ -22,6 +22,10 @@
 
 package org.seqdoop.hadoop_bam.util;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class Timer {
 	private long t0, td;
 


### PR DESCRIPTION
This deprecates Pair, Timer, and SeekableArrayStream since they are no longer used internally.