### PR TITLE
Add .gz and bgzf.gz files to infer unit tests

### DIFF
--- a/src/test/java/org/seqdoop/hadoop_bam/TestVCFFormat.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestVCFFormat.java
@@ -15,12 +15,15 @@ public class TestVCFFormat {
   public void testInferFromFilePath() throws IOException {
     assertEquals(VCFFormat.VCF, VCFFormat.inferFromFilePath("test.vcf"));
     assertEquals(VCFFormat.VCF, VCFFormat.inferFromFilePath("test.vcf.gz"));
+    assertEquals(VCFFormat.VCF, VCFFormat.inferFromFilePath("test.vcf.bgzf.gz"));
     assertNull(VCFFormat.inferFromFilePath("test.sam"));
   }
 
   @Test
   public void testInferFromData() throws IOException {
     assertEquals(VCFFormat.VCF, VCFFormat.inferFromData(stream("test.vcf")));
+    assertEquals(VCFFormat.VCF, VCFFormat.inferFromData(stream("test.vcf.gz")));
+    assertEquals(VCFFormat.VCF, VCFFormat.inferFromData(stream("test.vcf.bgzf.gz")));
     assertNull(VCFFormat.inferFromData(stream("test.sam")));
   }
 


### PR DESCRIPTION
Unit test fails, ```test.bgzf.gz``` should be recognized as BGZF-compressed VCF format
```bash
$ mvn test
...
Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec <<< FAILURE! - in org.seqdoop.hadoop_bam.TestVCFFormat
testInferFromData(org.seqdoop.hadoop_bam.TestVCFFormat)  Time elapsed: 0.005 sec  <<< FAILURE!
java.lang.AssertionError: expected:<VCF> but was:<BCF>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at org.seqdoop.hadoop_bam.TestVCFFormat.testInferFromData(TestVCFFormat.java:25)
```