### PR TITLE
Upgrade to htsjdk 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <htsjdk.version>2.2.1</htsjdk.version>
+        <htsjdk.version>2.3.0</htsjdk.version>
         <!-- CHANGE THIS FOR A DIFFERENT VERSION OF HADOOP -->
         <hadoop.version>2.2.0</hadoop.version>
         <!--

--- a/src/main/java/org/seqdoop/hadoop_bam/BAMSplitGuesser.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMSplitGuesser.java
@@ -108,10 +108,13 @@ public class BAMSplitGuesser extends BaseSplitGuesser {
 		throws IOException
 	{
 		// Use a reader to skip through the headers at the beginning of a BAM file, since
-		// the headers may exceed MAX_BYTES_READ in length
+		// the headers may exceed MAX_BYTES_READ in length. Don't close the reader
+		// otherwise it will close the underlying stream, which we continue to read from
+		// on subsequent calls to this method.
 		if (beg == 0) {
 			this.inFile.seek(beg);
-			SamReader open = SamReaderFactory.makeDefault().open(SamInputResource.of(inFile));
+			SamReader open = SamReaderFactory.makeDefault().setUseAsyncIo(false)
+					.open(SamInputResource.of(inFile));
 			SAMFileSpan span = open.indexing().getFilePointerSpanningReads();
 			if (span instanceof BAMFileSpan) {
 				return ((BAMFileSpan) span).getFirstOffset();

--- a/src/main/java/org/seqdoop/hadoop_bam/CRAMRecordReader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/CRAMRecordReader.java
@@ -40,8 +40,8 @@ public class CRAMRecordReader extends RecordReader<LongWritable, SAMRecordWritab
     final Path file  = fileSplit.getPath();
 
     String refSourcePath = conf.get(CRAMInputFormat.REFERENCE_SOURCE_PATH_PROPERTY);
-    ReferenceSource refSource = refSourcePath == null ? new ReferenceSource() :
-        new ReferenceSource(Paths.get(URI.create(refSourcePath)));
+    ReferenceSource refSource = new ReferenceSource(refSourcePath == null ? null :
+        Paths.get(URI.create(refSourcePath)));
 
     seekableStream = WrapSeekable.openPath(conf, file);
     start = fileSplit.getStart();

--- a/src/main/java/org/seqdoop/hadoop_bam/SAMRecordReader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/SAMRecordReader.java
@@ -148,7 +148,8 @@ public class SAMRecordReader
 
 	private SamReader createSamReader(InputStream in, ValidationStringency stringency) {
 		SamReaderFactory readerFactory = SamReaderFactory.makeDefault()
-				.setOption(SamReaderFactory.Option.EAGERLY_DECODE, false);
+				.setOption(SamReaderFactory.Option.EAGERLY_DECODE, false)
+				.setUseAsyncIo(false);
 		if (stringency != null) {
 			readerFactory.validationStringency(stringency);
 		}

--- a/src/main/java/org/seqdoop/hadoop_bam/util/GetSortedBAMHeader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/GetSortedBAMHeader.java
@@ -47,6 +47,7 @@ public final class GetSortedBAMHeader {
 
 		final SAMFileHeader h =
 				SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT)
+						.setUseAsyncIo(false)
 						.open(new File(args[0])).getFileHeader();
 		h.setSortOrder(SAMFileHeader.SortOrder.coordinate);
 

--- a/src/main/java/org/seqdoop/hadoop_bam/util/SAMHeaderReader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/SAMHeaderReader.java
@@ -61,7 +61,8 @@ public final class SAMHeaderReader {
 		final ValidationStringency
 			stringency = getValidationStringency(conf);
 		SamReaderFactory readerFactory = SamReaderFactory.makeDefault()
-				.setOption(SamReaderFactory.Option.EAGERLY_DECODE, false);
+				.setOption(SamReaderFactory.Option.EAGERLY_DECODE, false)
+				.setUseAsyncIo(false);
 		if (stringency != null) {
 			readerFactory.validationStringency(stringency);
 		}

--- a/src/test/java/org/seqdoop/hadoop_bam/TestBAMInputFormat.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestBAMInputFormat.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.task.JobContextImpl;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -37,14 +36,9 @@ public class TestBAMInputFormat {
   private TaskAttemptContext taskAttemptContext;
   private JobContext jobContext;
 
-  @Before
-  public void setup() throws Exception {
-    input = writeNameSortedBamFile().getAbsolutePath();
-  }
-
-  private File writeNameSortedBamFile() throws IOException {
-    SAMRecordSetBuilder samRecordSetBuilder =
-        new SAMRecordSetBuilder(true, SAMFileHeader.SortOrder.queryname);
+  private File writeBamFile(SAMFileHeader.SortOrder sortOrder) throws IOException {
+    // file will be both queryname and coordinate sorted, so use one or the other
+    SAMRecordSetBuilder samRecordSetBuilder = new SAMRecordSetBuilder(true, sortOrder);
     for (int i = 0; i < 1000; i++) {
       int chr = 20;
       int start1 = (i + 1) * 1000;
@@ -76,11 +70,13 @@ public class TestBAMInputFormat {
     bamWriter.close();
 
     // create BAM index
-    SamReader samReader = SamReaderFactory.makeDefault()
-        .enable(SamReaderFactory.Option.INCLUDE_SOURCE_IN_RECORDS)
-        .open(bamFile);
-    BAMIndexer.createIndex(samReader, new File(bamFile.getAbsolutePath() +
-        BAMIndex.BAMIndexSuffix));
+    if (sortOrder.equals(SAMFileHeader.SortOrder.coordinate)) {
+      SamReader samReader = SamReaderFactory.makeDefault()
+          .enable(SamReaderFactory.Option.INCLUDE_SOURCE_IN_RECORDS)
+          .open(bamFile);
+      BAMIndexer.createIndex(samReader, new File(bamFile.getAbsolutePath() +
+          BAMIndex.BAMIndexSuffix));
+    }
 
     return bamFile;
   }
@@ -137,6 +133,7 @@ public class TestBAMInputFormat {
 
   @Test
   public void testDontKeepPairedReadsTogether() throws Exception {
+    input = writeBamFile(SAMFileHeader.SortOrder.queryname).getAbsolutePath();
     completeSetup(false, null);
     jobContext.getConfiguration().setInt(FileInputFormat.SPLIT_MAXSIZE, 40000);
     BAMInputFormat inputFormat = new BAMInputFormat();
@@ -155,6 +152,7 @@ public class TestBAMInputFormat {
 
   @Test
   public void testKeepPairedReadsTogether() throws Exception {
+    input = writeBamFile(SAMFileHeader.SortOrder.queryname).getAbsolutePath();
     completeSetup(true, null);
     jobContext.getConfiguration().setInt(FileInputFormat.SPLIT_MAXSIZE, 40000);
     BAMInputFormat inputFormat = new BAMInputFormat();
@@ -171,6 +169,7 @@ public class TestBAMInputFormat {
 
   @Test
   public void testIntervals() throws Exception {
+    input = writeBamFile(SAMFileHeader.SortOrder.coordinate).getAbsolutePath();
     List<Interval> intervals = new ArrayList<Interval>();
     intervals.add(new Interval("chr21", 5000, 9999)); // includes two unmapped fragments
     intervals.add(new Interval("chr21", 20000, 22999));
@@ -187,6 +186,7 @@ public class TestBAMInputFormat {
 
   @Test
   public void testIntervalCoveringWholeChromosome() throws Exception {
+    input = writeBamFile(SAMFileHeader.SortOrder.coordinate).getAbsolutePath();
     List<Interval> intervals = new ArrayList<Interval>();
     intervals.add(new Interval("chr21", 1, 1000135));
 


### PR DESCRIPTION
Fix test due to changes in htsjdk (can't index a queryname sorted bam)

Use synchronous streams for SamReaderFactory to avoid readahead problems when underlying stream is accessed directly.