### PR TITLE
Upgrade to htsjdk 2.5.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <htsjdk.version>2.3.0</htsjdk.version>
+        <htsjdk.version>2.5.0</htsjdk.version>
         <!-- CHANGE THIS FOR A DIFFERENT VERSION OF HADOOP -->
         <hadoop.version>2.2.0</hadoop.version>
         <!--


### PR DESCRIPTION
We'd like to get a new release of Hadoop-BAM that is compatible with htsjdk 2.5, to use with GATK.
@tomwhite Do we need anything else ?  https://github.com/HadoopGenomics/Hadoop-BAM/issues/105 ?