### PR TITLE
Write splitting BAM indexes, and code for merging sharded BAM or CRAM files

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ below:
 | |`hadoopbam.anysam.write-header`|`true`|Whether to write the SAM header in each output file part. If `true`, call `setSAMHeader()` or `readSAMHeaderFrom()` to set the desired header.|
 |`BAMInputFormat`|`hadoopbam.bam.keep-paired-reads-together`|`false`|If `true`, ensure that for paired reads both reads in a pair are always in the same split for queryname-sorted BAM files.|
 | |`hadoopbam.bam.intervals`| |Only include reads that match the specified intervals. Intervals are comma-separated and follow the same syntax as the `-L` option in SAMtools. E.g. `chr1:1-20000,chr2:12000-20000`.|
+|`KeyIgnoringBAMOutputFormat`|`hadoopbam.bam.write-splitting-bai`|`false`|If `true`, write _.splitting-bai_ files for every BAM file.|
 |`CRAMInputFormat`|`hadoopbam.cram.reference-source-path`| |(Required.) The path to the reference. May be an `hdfs://` path.|
 |`FastqInputFormat`|`hbam.fastq-input.base-quality-encoding`|`sanger`|The encoding used for base qualities. One of `sanger` or `illumina`.|
 | |`hbam.fastq-input.filter-failed-qc`|`false`|If `true`, filter out reads that didn't pass quality checks.|

--- a/src/main/java/org/seqdoop/hadoop_bam/BAMInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMInputFormat.java
@@ -113,7 +113,7 @@ public class BAMInputFormat
 		return intervals;
 	}
 
-	private Path getIdxPath(Path path) {
+	static Path getIdxPath(Path path) {
 		return path.suffix(SplittingBAMIndexer.OUTPUT_FILE_EXTENSION);
 	}
 

--- a/src/main/java/org/seqdoop/hadoop_bam/BAMOutputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMOutputFormat.java
@@ -28,5 +28,14 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
  * org.apache.hadoop.mapreduce.OutputFormat}: contains no functionality.
  */
 public abstract class BAMOutputFormat<K>
-	extends FileOutputFormat<K,SAMRecordWritable>
-{}
+	extends FileOutputFormat<K,SAMRecordWritable> {
+	/**
+	 * If set to <code>true</code>, write <i>.splitting-bai</i> files for every BAM file
+	 * (defaults to <code>false</code>).
+	 * A splitting BAI file (not to be confused with a regular BAI file) contains an
+	 * index of offsets that the BAM file can be read from; they are used by
+	 * {@link BAMInputFormat} to construct splits.
+	 */
+	public static final String WRITE_SPLITTING_BAI =
+			"hadoopbam.bam.write-splitting-bai";
+}

--- a/src/main/java/org/seqdoop/hadoop_bam/KeyIgnoringBAMRecordWriter.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/KeyIgnoringBAMRecordWriter.java
@@ -55,7 +55,7 @@ public class KeyIgnoringBAMRecordWriter<K> extends BAMRecordWriter<K> {
 		super(output, header, writeHeader);
 	}
 
-	@Override public void write(K ignored, SAMRecordWritable rec) {
+	@Override public void write(K ignored, SAMRecordWritable rec) throws IOException {
 		writeAlignment(rec.get());
 	}
 }

--- a/src/main/java/org/seqdoop/hadoop_bam/SplittingBAMIndex.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/SplittingBAMIndex.java
@@ -28,6 +28,8 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.NavigableSet;
 import java.util.TreeSet;
 
@@ -69,6 +71,10 @@ public final class SplittingBAMIndex {
 				"should contain at least 1 offset and the file size");
 	}
 
+	public List<Long> getVirtualOffsets() {
+		return new ArrayList<>(virtualOffsets);
+	}
+
 	public Long prevAlignment(final long filePos) {
 		return virtualOffsets.floor(filePos << 16);
 	}
@@ -97,6 +103,11 @@ public final class SplittingBAMIndex {
 	@Override
 	public int hashCode() {
 		return virtualOffsets != null ? virtualOffsets.hashCode() : 0;
+	}
+
+	@Override
+	public String toString() {
+		return virtualOffsets.toString();
 	}
 
 	/** Writes some statistics about each splitting BAM index file given as an

--- a/src/main/java/org/seqdoop/hadoop_bam/SplittingBAMIndexer.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/SplittingBAMIndexer.java
@@ -194,6 +194,13 @@ public final class SplittingBAMIndexer {
 		count++;
 	}
 
+	void processAlignment(final long virtualOffset) throws IOException {
+		if (count == 0 || (count + 1) % granularity == 0) {
+			writeVirtualOffset(virtualOffset);
+		}
+		count++;
+	}
+
 	private long getPos(SAMFileSpan filePointer) {
 		// Use reflection since BAMFileSpan is package private in htsjdk 1.141. Note that
 		// Hadoop-BAM cannot use a later version of htsjdk since it requires Java 8.

--- a/src/main/java/org/seqdoop/hadoop_bam/SplittingBAMIndexer.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/SplittingBAMIndexer.java
@@ -221,7 +221,12 @@ public final class SplittingBAMIndexer {
 		}
 	}
 
-	private void writeVirtualOffset(long virtualOffset) throws IOException {
+	/**
+	 * Write the given virtual offset to the index. This method is for internal use only.
+	 * @param virtualOffset virtual file pointer
+	 * @throws IOException
+	 */
+	public void writeVirtualOffset(long virtualOffset) throws IOException {
 		lb.put(0, virtualOffset);
 		out.write(byteBuffer.array());
 	}

--- a/src/main/java/org/seqdoop/hadoop_bam/util/BGZFCodec.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/BGZFCodec.java
@@ -28,6 +28,8 @@ import org.apache.hadoop.io.compress.SplittableCompressionCodec;
  */
 public class BGZFCodec extends GzipCodec implements SplittableCompressionCodec {
 
+  public static final String DEFAULT_EXTENSION = ".bgz";
+
   @Override
   public CompressionOutputStream createOutputStream(OutputStream out) throws IOException {
     return new BGZFCompressionOutputStream(out);
@@ -64,6 +66,6 @@ public class BGZFCodec extends GzipCodec implements SplittableCompressionCodec {
 
   @Override
   public String getDefaultExtension() {
-    return ".bgz";
+    return DEFAULT_EXTENSION;
   }
 }

--- a/src/main/java/org/seqdoop/hadoop_bam/util/NIOFileUtil.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/NIOFileUtil.java
@@ -18,6 +18,8 @@ class NIOFileUtil {
   private NIOFileUtil() {
   }
 
+  public static final String PARTS_GLOB = "glob:**/part-[mr]-[0-9][0-9][0-9][0-9][0-9]*";
+
   /**
    * Convert the given path string to a {@link Path} object.
    * @param path the path to convert

--- a/src/main/java/org/seqdoop/hadoop_bam/util/NIOFileUtil.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/NIOFileUtil.java
@@ -1,0 +1,88 @@
+package org.seqdoop.hadoop_bam.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class NIOFileUtil {
+  private NIOFileUtil() {
+  }
+
+  /**
+   * Convert the given path string to a {@link Path} object.
+   * @param path the path to convert
+   * @return a {@link Path} object
+   */
+  public static Path asPath(String path) {
+    URI uri = URI.create(path);
+    return uri.getScheme() == null ? Paths.get(path) : Paths.get(uri);
+  }
+
+  /**
+   * Delete the given directory and all of its contents if non-empty.
+   * @param directory the directory to delete
+   * @throws IOException
+   */
+  public static void deleteRecursive(Path directory) throws IOException {
+    Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+      }
+      @Override
+      public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+        Files.delete(dir);
+        return FileVisitResult.CONTINUE;
+      }
+    });
+  }
+
+  /**
+   * Returns all the files in a directory that match the given pattern, and that don't
+   * have the given extension.
+   * @param directory the directory to look for files in, subdirectories are not
+   *                  considered
+   * @param syntaxAndPattern the syntax and pattern to use for matching (see
+   * {@link java.nio.file.FileSystem#getPathMatcher}
+   * @param excludesExt the extension to exclude, or null to exclude nothing
+   * @return a list of files, sorted by name
+   * @throws IOException
+   */
+  public static List<Path> getFilesMatching(Path directory,
+      String syntaxAndPattern, String excludesExt) throws IOException {
+    PathMatcher matcher = directory.getFileSystem().getPathMatcher(syntaxAndPattern);
+    List<Path> parts = Files.walk(directory)
+        .filter(matcher::matches)
+        .filter(path -> excludesExt == null || !path.toString().endsWith(excludesExt))
+        .collect(Collectors.toList());
+    Collections.sort(parts);
+    return parts;
+  }
+
+  /**
+   * Merge the given part files in order into an output stream.
+   * @param parts the part files to merge
+   * @param out the stream to write each file into, in order
+   * @throws IOException
+   */
+  public static void mergeInto(List<Path> parts, OutputStream out)
+      throws IOException {
+    for (final Path part : parts) {
+      Files.copy(part, out);
+    }
+    for (final Path part : parts) {
+      Files.delete(part);
+    }
+  }
+}

--- a/src/main/java/org/seqdoop/hadoop_bam/util/SAMFileMerger.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/SAMFileMerger.java
@@ -59,8 +59,7 @@ public class SAMFileMerger {
           "path: " + partPath);
     }
 
-    List<Path> parts = getFilesMatching(partPath,
-        "glob:**/part-[mr]-[0-9][0-9][0-9][0-9][0-9]*",
+    List<Path> parts = getFilesMatching(partPath, NIOFileUtil.PARTS_GLOB,
         SplittingBAMIndexer.OUTPUT_FILE_EXTENSION);
     if (parts.isEmpty()) {
       throw new IllegalArgumentException("Could not write bam file because no part " +
@@ -83,10 +82,12 @@ public class SAMFileMerger {
 
     final Path outputSplittingBaiPath = outputPath.resolveSibling(
         outputPath.getFileName() + SplittingBAMIndexer.OUTPUT_FILE_EXTENSION);
+    Files.deleteIfExists(outputSplittingBaiPath);
     try (final OutputStream out = Files.newOutputStream(outputSplittingBaiPath)) {
       mergeSplittingBaiFiles(out, partPath, headerLength, fileLength);
     } catch (IOException e) {
       deleteRecursive(outputSplittingBaiPath);
+      throw e;
     }
 
     deleteRecursive(partPath);
@@ -104,8 +105,7 @@ public class SAMFileMerger {
   static void mergeSplittingBaiFiles(OutputStream out, Path directory, long headerLength,
       long fileLength) throws IOException {
     final List<Path> parts = getFilesMatching(directory,
-        "glob:**/part-[mr]-[0-9][0-9][0-9][0-9][0-9]*" +
-            SplittingBAMIndexer.OUTPUT_FILE_EXTENSION, null);
+        NIOFileUtil.PARTS_GLOB + SplittingBAMIndexer.OUTPUT_FILE_EXTENSION, null);
     if (parts.isEmpty()) {
       return; // nothing to merge
     }

--- a/src/main/java/org/seqdoop/hadoop_bam/util/SAMFileMerger.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/SAMFileMerger.java
@@ -1,0 +1,194 @@
+package org.seqdoop.hadoop_bam.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.io.CountingOutputStream;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.cram.build.CramIO;
+import htsjdk.samtools.cram.common.CramVersions;
+import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
+import htsjdk.samtools.util.BlockCompressedStreamConstants;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.seqdoop.hadoop_bam.KeyIgnoringAnySAMOutputFormat;
+import org.seqdoop.hadoop_bam.SAMFormat;
+import org.seqdoop.hadoop_bam.SplittingBAMIndex;
+import org.seqdoop.hadoop_bam.SplittingBAMIndexer;
+
+/**
+ * Merges headerless BAM or CRAM files produced by {@link KeyIgnoringAnySAMOutputFormat}
+ * into a single file.
+ */
+public class SAMFileMerger {
+
+  private SAMFileMerger() {
+  }
+
+  /**
+   * Merge part file shards produced by {@link KeyIgnoringAnySAMOutputFormat} into a
+   * single file with the given header.
+   * @param partDirectory the directory containing part files
+   * @param outputFile the file to write the merged file to
+   * @param samOutputFormat the format (must be BAM or CRAM; SAM is not supported)
+   * @param header the header for the merged file
+   * @throws IOException
+   */
+  public static void mergeParts(final String partDirectory, final String outputFile,
+      final SAMFormat samOutputFormat, final SAMFileHeader header) throws IOException {
+
+    final String outputParentDir = partDirectory;
+    // First, check for the _SUCCESS file.
+    final String successFile = partDirectory + "/_SUCCESS";
+    final org.apache.hadoop.fs.Path successPath = new org.apache.hadoop.fs.Path(successFile);
+    final Configuration conf = new Configuration();
+
+    //it's important that we get the appropriate file system by requesting it from the path
+    final FileSystem fs = successPath.getFileSystem(conf);
+    if (!fs.exists(successPath)) {
+      throw new NoSuchFileException(successFile, null, "Unable to find _SUCCESS file");
+    }
+    final org.apache.hadoop.fs.Path partPath = new org.apache.hadoop.fs.Path(partDirectory);
+    final org.apache.hadoop.fs.Path outputPath = new org.apache.hadoop.fs.Path(outputFile);
+    final org.apache.hadoop.fs.Path tmpPath = new org.apache.hadoop.fs.Path(outputParentDir + "tmp" + UUID.randomUUID());
+
+    fs.rename(partPath, tmpPath);
+    fs.delete(outputPath, true);
+
+    long headerLength;
+    try (final CountingOutputStream out =
+             new CountingOutputStream(fs.create(outputPath))) {
+      if (header != null) {
+        new SAMOutputPreparer().prepareForRecords(out, samOutputFormat, header); // write the header
+
+      }
+      headerLength = out.getCount();
+      mergeInto(out, tmpPath, conf);
+      writeTerminatorBlock(out, samOutputFormat);
+    }
+    long fileLength = fs.getFileStatus(outputPath).getLen();
+
+    final org.apache.hadoop.fs.Path outputSplittingBaiPath = outputPath.suffix
+        (SplittingBAMIndexer.OUTPUT_FILE_EXTENSION);
+    try (final OutputStream out = fs.create(outputSplittingBaiPath)) {
+      mergeSplittingBaiFiles(out, tmpPath, conf, headerLength, fileLength);
+    } catch (IOException e) {
+      fs.delete(outputSplittingBaiPath, false);
+    }
+
+    fs.delete(tmpPath, true);
+
+  }
+
+  static void mergeInto(OutputStream out, org.apache.hadoop.fs.Path directory, Configuration conf) throws IOException {
+    final FileSystem fs = directory.getFileSystem(conf);
+    final FileStatus[] parts = getFragments(directory, fs);
+
+    if( parts.length == 0){
+      throw new IllegalArgumentException("Could not write bam file because no part files were found.");
+    }
+
+    for (final FileStatus part : parts) {
+      try (final InputStream in = fs.open(part.getPath())) {
+        org.apache.hadoop.io.IOUtils.copyBytes(in, out, conf, false);
+      }
+    }
+    for (final FileStatus part : parts) {
+      fs.delete(part.getPath(), false);
+    }
+  }
+
+  @VisibleForTesting
+  static FileStatus[] getFragments( final org.apache.hadoop.fs.Path directory, final FileSystem fs ) throws IOException {
+    final FileStatus[] parts = fs.globStatus(new org.apache.hadoop.fs.Path(directory,
+        "part-[mr]-[0-9][0-9][0-9][0-9][0-9]*"),
+        path -> !path.getName().endsWith(SplittingBAMIndexer.OUTPUT_FILE_EXTENSION));
+
+    // FileSystem.globStatus() has a known bug that causes it to not sort the array returned by
+    // name (despite claiming to): https://issues.apache.org/jira/browse/HADOOP-10798
+    // Because of this bug, we do an explicit sort here to avoid assembling the bam fragments
+    // in the wrong order.
+    Arrays.sort(parts);
+
+    return parts;
+  }
+
+  //Terminate the aggregated output stream with an appropriate SAMOutputFormat-dependent terminator block
+  private static void writeTerminatorBlock(final OutputStream out, final SAMFormat samOutputFormat) throws IOException {
+    if (SAMFormat.CRAM == samOutputFormat) {
+      CramIO.issueEOF(CramVersions.DEFAULT_CRAM_VERSION, out); // terminate with CRAM EOF container
+    }
+    else {
+      out.write(BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK); // add the BGZF terminator
+    }
+  }
+
+  static void mergeSplittingBaiFiles(OutputStream out, org.apache.hadoop.fs.Path
+      directory, Configuration conf, long headerLength, long fileLength) throws
+      IOException {
+    final FileSystem fs = directory.getFileSystem(conf);
+    final FileStatus[] parts = getSplittingBaiFiles(directory, fs);
+
+    if( parts.length == 0){
+      return; // nothing to merge
+    }
+
+    List<Long> mergedVirtualOffsets = new ArrayList<>();
+    long partFileOffset = headerLength;
+    for (final FileStatus part : parts) {
+      try (final InputStream in = fs.open(part.getPath())) {
+        SplittingBAMIndex index = new SplittingBAMIndex(in);
+        LinkedList<Long> virtualOffsets = new LinkedList<>(index.getVirtualOffsets());
+        for (int i = 0; i < virtualOffsets.size() - 1; i++) {
+          long virtualOffset = virtualOffsets.get(i);
+          mergedVirtualOffsets.add(shiftVirtualFilePointer(virtualOffset, partFileOffset));
+        }
+        long partLength = virtualOffsets.getLast();
+        partFileOffset += (partLength >> 16);
+      }
+    }
+
+
+    SplittingBAMIndexer splittingBAMIndexer = new SplittingBAMIndexer(out);
+    for (Long offset : mergedVirtualOffsets) {
+      splittingBAMIndexer.writeVirtualOffset(offset);
+    }
+    splittingBAMIndexer.finish(partFileOffset);
+    int terminatingBlockLength = BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK.length;
+    if (partFileOffset + terminatingBlockLength != fileLength) {
+      throw new IOException("Part file length mismatch. Last part file offset is " +
+          partFileOffset + ", expected: " + (fileLength - terminatingBlockLength));
+    }
+
+    for (final FileStatus part : parts) {
+      fs.delete(part.getPath(), false);
+    }
+  }
+
+  private static long shiftVirtualFilePointer(long virtualFilePointer, long offset) {
+    long blockAddress = BlockCompressedFilePointerUtil.getBlockAddress(virtualFilePointer);
+    int blockOffset = BlockCompressedFilePointerUtil.getBlockOffset(virtualFilePointer);
+    return (blockAddress + offset) << 16 | (long) blockOffset;
+  }
+
+  static FileStatus[] getSplittingBaiFiles( final org.apache.hadoop.fs.Path directory, final FileSystem fs ) throws IOException {
+    final FileStatus[] parts = fs.globStatus(new org.apache.hadoop.fs.Path(directory,
+            "part-[mr]-[0-9][0-9][0-9][0-9][0-9]*" + SplittingBAMIndexer.OUTPUT_FILE_EXTENSION));
+
+    // FileSystem.globStatus() has a known bug that causes it to not sort the array returned by
+    // name (despite claiming to): https://issues.apache.org/jira/browse/HADOOP-10798
+    // Because of this bug, we do an explicit sort here to avoid assembling the bam fragments
+    // in the wrong order.
+    Arrays.sort(parts);
+
+    return parts;
+  }
+}

--- a/src/main/java/org/seqdoop/hadoop_bam/util/SAMFileMerger.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/SAMFileMerger.java
@@ -1,6 +1,5 @@
 package org.seqdoop.hadoop_bam.util;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.CountingOutputStream;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.cram.build.CramIO;
@@ -10,24 +9,21 @@ import htsjdk.samtools.util.BlockCompressedStreamConstants;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.seqdoop.hadoop_bam.KeyIgnoringAnySAMOutputFormat;
 import org.seqdoop.hadoop_bam.SAMFormat;
 import org.seqdoop.hadoop_bam.SplittingBAMIndex;
 import org.seqdoop.hadoop_bam.SplittingBAMIndexer;
+
+import static org.seqdoop.hadoop_bam.util.NIOFileUtil.asPath;
+import static org.seqdoop.hadoop_bam.util.NIOFileUtil.deleteRecursive;
+import static org.seqdoop.hadoop_bam.util.NIOFileUtil.getFilesMatching;
+import static org.seqdoop.hadoop_bam.util.NIOFileUtil.mergeInto;
 
 /**
  * Merges headerless BAM or CRAM files produced by {@link KeyIgnoringAnySAMOutputFormat}
@@ -63,6 +59,14 @@ public class SAMFileMerger {
           "path: " + partPath);
     }
 
+    List<Path> parts = getFilesMatching(partPath,
+        "glob:**/part-[mr]-[0-9][0-9][0-9][0-9][0-9]*",
+        SplittingBAMIndexer.OUTPUT_FILE_EXTENSION);
+    if (parts.isEmpty()) {
+      throw new IllegalArgumentException("Could not write bam file because no part " +
+          "files were found in " + partPath);
+    }
+
     Files.deleteIfExists(outputPath);
 
     long headerLength;
@@ -72,7 +76,7 @@ public class SAMFileMerger {
         new SAMOutputPreparer().prepareForRecords(out, samOutputFormat, header); // write the header
       }
       headerLength = out.getCount();
-      mergeInto(out, partPath);
+      mergeInto(parts, out);
       writeTerminatorBlock(out, samOutputFormat);
     }
     long fileLength = Files.size(outputPath);
@@ -88,51 +92,6 @@ public class SAMFileMerger {
     deleteRecursive(partPath);
   }
 
-  private static Path asPath(String path) {
-    URI uri = URI.create(path);
-    return uri.getScheme() == null ? Paths.get(path) : Paths.get(uri);
-  }
-
-  private static void deleteRecursive(Path directory) throws IOException {
-    Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
-      @Override
-      public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-        Files.delete(file);
-        return FileVisitResult.CONTINUE;
-      }
-      @Override
-      public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-        Files.delete(dir);
-        return FileVisitResult.CONTINUE;
-      }
-    });
-  }
-
-  private static void mergeInto(OutputStream out, Path directory) throws IOException {
-    final List<Path> parts = getFragments(directory);
-    if (parts.isEmpty()) {
-      throw new IllegalArgumentException("Could not write bam file because no part " +
-          "files were found in " + directory);
-    }
-    for (final Path part : parts) {
-      Files.copy(part, out);
-    }
-    for (final Path part : parts) {
-      Files.delete(part);
-    }
-  }
-
-  @VisibleForTesting
-  static List<Path> getFragments(final Path directory) throws IOException {
-    PathMatcher matcher = directory.getFileSystem().getPathMatcher("glob:**/part-[mr]-[0-9][0-9][0-9][0-9][0-9]*");
-    List<Path> parts = Files.walk(directory)
-        .filter(matcher::matches)
-        .filter(path -> !path.toString().endsWith(SplittingBAMIndexer.OUTPUT_FILE_EXTENSION))
-        .collect(Collectors.toList());
-    Collections.sort(parts);
-    return parts;
-  }
-
   //Terminate the aggregated output stream with an appropriate SAMOutputFormat-dependent terminator block
   private static void writeTerminatorBlock(final OutputStream out, final SAMFormat samOutputFormat) throws IOException {
     if (SAMFormat.CRAM == samOutputFormat) {
@@ -144,8 +103,9 @@ public class SAMFileMerger {
 
   static void mergeSplittingBaiFiles(OutputStream out, Path directory, long headerLength,
       long fileLength) throws IOException {
-    final List<Path> parts = getSplittingBaiFiles(directory);
-
+    final List<Path> parts = getFilesMatching(directory,
+        "glob:**/part-[mr]-[0-9][0-9][0-9][0-9][0-9]*" +
+            SplittingBAMIndexer.OUTPUT_FILE_EXTENSION, null);
     if (parts.isEmpty()) {
       return; // nothing to merge
     }
@@ -186,13 +146,5 @@ public class SAMFileMerger {
     long blockAddress = BlockCompressedFilePointerUtil.getBlockAddress(virtualFilePointer);
     int blockOffset = BlockCompressedFilePointerUtil.getBlockOffset(virtualFilePointer);
     return (blockAddress + offset) << 16 | (long) blockOffset;
-  }
-
-  static List<Path> getSplittingBaiFiles(final Path directory) throws IOException {
-    PathMatcher matcher = directory.getFileSystem()
-        .getPathMatcher("glob:**/part-[mr]-[0-9][0-9][0-9][0-9][0-9]*" + SplittingBAMIndexer.OUTPUT_FILE_EXTENSION);
-    List<Path> parts = Files.walk(directory).filter(matcher::matches).collect(Collectors.toList());
-    Collections.sort(parts);
-    return parts;
   }
 }

--- a/src/main/java/org/seqdoop/hadoop_bam/util/VCFFileMerger.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/VCFFileMerger.java
@@ -1,0 +1,170 @@
+package org.seqdoop.hadoop_bam.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.BlockCompressedStreamConstants;
+import htsjdk.tribble.util.TabixUtils;
+import htsjdk.variant.variantcontext.writer.VariantContextWriter;
+import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
+import htsjdk.variant.vcf.VCFHeader;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPOutputStream;
+import org.seqdoop.hadoop_bam.KeyIgnoringVCFOutputFormat;
+import org.seqdoop.hadoop_bam.VCFFormat;
+
+/**
+ * Merges headerless VCF files produced by {@link KeyIgnoringVCFOutputFormat}
+ * into a single file.
+ */
+public class VCFFileMerger {
+  /**
+   * Merge part file shards produced by {@link KeyIgnoringVCFOutputFormat} into a
+   * single file with the given header.
+   * @param partDirectory the directory containing part files
+   * @param outputFile the file to write the merged file to
+   * @param header the header for the merged file
+   * @throws IOException
+   */
+  public static void mergeParts(final String partDirectory, final String outputFile,
+      final VCFHeader header) throws IOException {
+    // First, check for the _SUCCESS file.
+    final String successFile = partDirectory + "/_SUCCESS";
+    final Path successPath = asPath(successFile);
+    if (!Files.exists(successPath)) {
+      throw new NoSuchFileException(successFile, null, "Unable to find _SUCCESS file");
+    }
+    final Path partPath = asPath(partDirectory);
+    final Path outputPath = asPath(outputFile);
+    if (partPath.equals(outputPath)) {
+      throw new IllegalArgumentException("Cannot merge parts into output with same " +
+          "path: " + partPath);
+    }
+
+    Files.deleteIfExists(outputPath);
+
+    try (final OutputStream out = Files.newOutputStream(outputPath)) {
+      boolean blockCompressed = writeHeader(out, outputPath, partPath, header);
+      mergeInto(out, partPath);
+      if (blockCompressed) {
+        writeTerminatorBlock(out);
+      }
+    }
+
+    deleteRecursive(partPath);
+  }
+
+  private static Path asPath(String path) {
+    URI uri = URI.create(path);
+    return uri.getScheme() == null ? Paths.get(path) : Paths.get(uri);
+  }
+
+  /**
+   * @return whether the output is block compressed
+   */
+  private static boolean writeHeader(OutputStream out, Path outputPath, Path partPath,
+      VCFHeader header) throws IOException {
+    if (header == null) {
+      return false;
+    }
+    boolean blockCompressed = isBlockCompressed(partPath);
+    boolean bgzExtension = outputPath.toString().endsWith(BGZFCodec.DEFAULT_EXTENSION);
+    if (blockCompressed && !bgzExtension) {
+      System.err.println("WARNING: parts are block compressed, but output does not " +
+          "have .bgz extension: " + outputPath);
+    } else if (!blockCompressed && bgzExtension) {
+      System.err.println("WARNING: parts are not block compressed, but output has a " +
+          ".bgz extension: " + outputPath);
+    }
+    boolean gzipCompressed = isGzipCompressed(partPath);
+    OutputStream headerOut;
+    if (blockCompressed) {
+      headerOut = new BlockCompressedOutputStream(out, null);
+    } else if (gzipCompressed) {
+      headerOut = new GZIPOutputStream(out);
+    } else {
+      headerOut = out;
+    }
+    VariantContextWriter writer = new VariantContextWriterBuilder().clearOptions()
+        .setOutputVCFStream(headerOut).build();
+    writer.writeHeader(header);
+    headerOut.flush();
+    if (headerOut instanceof GZIPOutputStream) {
+      ((GZIPOutputStream) headerOut).finish();
+    }
+    return blockCompressed;
+  }
+
+  private static boolean isBlockCompressed(Path directory) throws IOException {
+    final List<Path> parts = getFragments(directory);
+    try (InputStream in = new BufferedInputStream(Files.newInputStream(parts.get(0)))) {
+      return BlockCompressedInputStream.isValidFile(in);
+    }
+  }
+
+  private static boolean isGzipCompressed(Path directory) throws IOException {
+    final List<Path> parts = getFragments(directory);
+    try (InputStream in = new BufferedInputStream(Files.newInputStream(parts.get(0)))) {
+      return VCFFormat.isGzip(in);
+    }
+  }
+
+  private static void mergeInto(OutputStream out, Path directory) throws IOException {
+    final List<Path> parts = getFragments(directory);
+    for (final Path part : parts) {
+      Files.copy(part, out);
+    }
+    for (final Path part : parts) {
+      Files.delete(part);
+    }
+  }
+
+  @VisibleForTesting
+  static List<Path> getFragments(final Path directory) throws IOException {
+    PathMatcher matcher = directory.getFileSystem().getPathMatcher("glob:**/part-[mr]-[0-9][0-9][0-9][0-9][0-9]*");
+    List<Path> parts = Files.walk(directory)
+        .filter(matcher::matches)
+        .filter(path -> !path.toString().endsWith(TabixUtils.STANDARD_INDEX_EXTENSION))
+        .collect(Collectors.toList());
+    Collections.sort(parts);
+    if (parts.isEmpty()) {
+      throw new IllegalArgumentException("Could not write vcf file because no part " +
+          "files were found in " + directory);
+    }
+    return parts;
+  }
+
+  private static void writeTerminatorBlock(final OutputStream out) throws IOException {
+    out.write(BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK); // add the BGZF terminator
+  }
+
+  private static void deleteRecursive(Path directory) throws IOException {
+    Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+      }
+      @Override
+      public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+        Files.delete(dir);
+        return FileVisitResult.CONTINUE;
+      }
+    });
+  }
+}

--- a/src/main/java/org/seqdoop/hadoop_bam/util/VCFFileMerger.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/VCFFileMerger.java
@@ -1,6 +1,5 @@
 package org.seqdoop.hadoop_bam.util;
 
-import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
 import htsjdk.samtools.util.BlockCompressedStreamConstants;
@@ -12,21 +11,18 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.zip.GZIPOutputStream;
 import org.seqdoop.hadoop_bam.KeyIgnoringVCFOutputFormat;
 import org.seqdoop.hadoop_bam.VCFFormat;
+
+import static org.seqdoop.hadoop_bam.util.NIOFileUtil.asPath;
+import static org.seqdoop.hadoop_bam.util.NIOFileUtil.deleteRecursive;
+import static org.seqdoop.hadoop_bam.util.NIOFileUtil.getFilesMatching;
+import static org.seqdoop.hadoop_bam.util.NIOFileUtil.mergeInto;
 
 /**
  * Merges headerless VCF files produced by {@link KeyIgnoringVCFOutputFormat}
@@ -56,11 +52,19 @@ public class VCFFileMerger {
           "path: " + partPath);
     }
 
+    List<Path> parts = getFilesMatching(partPath,
+        "glob:**/part-[mr]-[0-9][0-9][0-9][0-9][0-9]*",
+        TabixUtils.STANDARD_INDEX_EXTENSION);
+    if (parts.isEmpty()) {
+      throw new IllegalArgumentException("Could not write bam file because no part " +
+          "files were found in " + partPath);
+    }
+
     Files.deleteIfExists(outputPath);
 
     try (final OutputStream out = Files.newOutputStream(outputPath)) {
-      boolean blockCompressed = writeHeader(out, outputPath, partPath, header);
-      mergeInto(out, partPath);
+      boolean blockCompressed = writeHeader(out, outputPath, parts, header);
+      mergeInto(parts, out);
       if (blockCompressed) {
         writeTerminatorBlock(out);
       }
@@ -69,20 +73,15 @@ public class VCFFileMerger {
     deleteRecursive(partPath);
   }
 
-  private static Path asPath(String path) {
-    URI uri = URI.create(path);
-    return uri.getScheme() == null ? Paths.get(path) : Paths.get(uri);
-  }
-
   /**
    * @return whether the output is block compressed
    */
-  private static boolean writeHeader(OutputStream out, Path outputPath, Path partPath,
+  private static boolean writeHeader(OutputStream out, Path outputPath, List<Path> parts,
       VCFHeader header) throws IOException {
     if (header == null) {
       return false;
     }
-    boolean blockCompressed = isBlockCompressed(partPath);
+    boolean blockCompressed = isBlockCompressed(parts);
     boolean bgzExtension = outputPath.toString().endsWith(BGZFCodec.DEFAULT_EXTENSION);
     if (blockCompressed && !bgzExtension) {
       System.err.println("WARNING: parts are block compressed, but output does not " +
@@ -91,7 +90,7 @@ public class VCFFileMerger {
       System.err.println("WARNING: parts are not block compressed, but output has a " +
           ".bgz extension: " + outputPath);
     }
-    boolean gzipCompressed = isGzipCompressed(partPath);
+    boolean gzipCompressed = isGzipCompressed(parts);
     OutputStream headerOut;
     if (blockCompressed) {
       headerOut = new BlockCompressedOutputStream(out, null);
@@ -110,61 +109,19 @@ public class VCFFileMerger {
     return blockCompressed;
   }
 
-  private static boolean isBlockCompressed(Path directory) throws IOException {
-    final List<Path> parts = getFragments(directory);
+  private static boolean isBlockCompressed(List<Path> parts) throws IOException {
     try (InputStream in = new BufferedInputStream(Files.newInputStream(parts.get(0)))) {
       return BlockCompressedInputStream.isValidFile(in);
     }
   }
 
-  private static boolean isGzipCompressed(Path directory) throws IOException {
-    final List<Path> parts = getFragments(directory);
+  private static boolean isGzipCompressed(List<Path> parts) throws IOException {
     try (InputStream in = new BufferedInputStream(Files.newInputStream(parts.get(0)))) {
       return VCFFormat.isGzip(in);
     }
   }
 
-  private static void mergeInto(OutputStream out, Path directory) throws IOException {
-    final List<Path> parts = getFragments(directory);
-    for (final Path part : parts) {
-      Files.copy(part, out);
-    }
-    for (final Path part : parts) {
-      Files.delete(part);
-    }
-  }
-
-  @VisibleForTesting
-  static List<Path> getFragments(final Path directory) throws IOException {
-    PathMatcher matcher = directory.getFileSystem().getPathMatcher("glob:**/part-[mr]-[0-9][0-9][0-9][0-9][0-9]*");
-    List<Path> parts = Files.walk(directory)
-        .filter(matcher::matches)
-        .filter(path -> !path.toString().endsWith(TabixUtils.STANDARD_INDEX_EXTENSION))
-        .collect(Collectors.toList());
-    Collections.sort(parts);
-    if (parts.isEmpty()) {
-      throw new IllegalArgumentException("Could not write vcf file because no part " +
-          "files were found in " + directory);
-    }
-    return parts;
-  }
-
   private static void writeTerminatorBlock(final OutputStream out) throws IOException {
     out.write(BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK); // add the BGZF terminator
-  }
-
-  private static void deleteRecursive(Path directory) throws IOException {
-    Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
-      @Override
-      public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-        Files.delete(file);
-        return FileVisitResult.CONTINUE;
-      }
-      @Override
-      public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-        Files.delete(dir);
-        return FileVisitResult.CONTINUE;
-      }
-    });
   }
 }

--- a/src/test/java/org/seqdoop/hadoop_bam/BAMTestUtil.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/BAMTestUtil.java
@@ -1,0 +1,90 @@
+package org.seqdoop.hadoop_bam;
+
+import htsjdk.samtools.BAMIndex;
+import htsjdk.samtools.BAMIndexer;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordSetBuilder;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import java.io.File;
+import java.io.IOException;
+
+class BAMTestUtil {
+  public static File writeBamFile(int numPairs, SAMFileHeader.SortOrder sortOrder)
+      throws IOException {
+    // file will be both queryname and coordinate sorted, so use one or the other
+    SAMRecordSetBuilder samRecordSetBuilder = new SAMRecordSetBuilder(true, sortOrder);
+    for (int i = 0; i < numPairs; i++) {
+      int chr = 20;
+      int start1 = (i + 1) * 1000;
+      int start2 = start1 + 100;
+      if (i == 5) { // add two unmapped fragments instead of a mapped pair
+        samRecordSetBuilder.addFrag(String.format("test-read-%03d-1", i), chr, start1,
+            false, true, null,
+            null,
+            -1, false);
+        samRecordSetBuilder.addFrag(String.format("test-read-%03d-2", i), chr, start2,
+            false, true, null,
+            null,
+            -1, false);
+
+      } else {
+        samRecordSetBuilder.addPair(String.format("test-read-%03d", i), chr, start1,
+            start2);
+      }
+    }
+
+    final File bamFile = File.createTempFile("test", ".bam");
+    bamFile.deleteOnExit();
+    SAMFileHeader samHeader = samRecordSetBuilder.getHeader();
+    final SAMFileWriter bamWriter = new SAMFileWriterFactory()
+        .makeSAMOrBAMWriter(samHeader, true, bamFile);
+    for (final SAMRecord rec : samRecordSetBuilder.getRecords()) {
+      bamWriter.addAlignment(rec);
+    }
+    bamWriter.close();
+
+    // create BAM index
+    if (sortOrder.equals(SAMFileHeader.SortOrder.coordinate)) {
+      SamReader samReader = SamReaderFactory.makeDefault()
+          .enable(SamReaderFactory.Option.INCLUDE_SOURCE_IN_RECORDS)
+          .open(bamFile);
+      BAMIndexer.createIndex(samReader, new File(bamFile.getAbsolutePath()
+          .replaceFirst("\\.bam$", BAMIndex.BAMIndexSuffix)));
+    }
+
+    return bamFile;
+  }
+
+  public static File writeBamFileWithLargeHeader() throws IOException {
+    SAMRecordSetBuilder samRecordSetBuilder =
+        new SAMRecordSetBuilder(true, SAMFileHeader.SortOrder.queryname);
+    for (int i = 0; i < 1000; i++) {
+      int chr = 20;
+      int start1 = (i + 1) * 1000;
+      int start2 = start1 + 100;
+      samRecordSetBuilder.addPair(String.format("test-read-%03d", i), chr, start1,
+          start2);
+    }
+
+    final File bamFile = File.createTempFile("test", ".bam");
+    bamFile.deleteOnExit();
+    SAMFileHeader samHeader = samRecordSetBuilder.getHeader();
+    StringBuffer sb = new StringBuffer();
+    for (int i = 0; i < 1000000; i++) {
+      sb.append("0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789");
+    }
+    samHeader.addComment(sb.toString());
+    final SAMFileWriter bamWriter = new SAMFileWriterFactory()
+        .makeSAMOrBAMWriter(samHeader, true, bamFile);
+    for (final SAMRecord rec : samRecordSetBuilder.getRecords()) {
+      bamWriter.addAlignment(rec);
+    }
+    bamWriter.close();
+
+    return bamFile;
+  }
+}

--- a/src/test/java/org/seqdoop/hadoop_bam/util/TestVCFFileMerger.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/util/TestVCFFileMerger.java
@@ -1,0 +1,48 @@
+package org.seqdoop.hadoop_bam.util;
+
+import htsjdk.variant.vcf.VCFHeader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestVCFFileMerger {
+
+  private String partsDirectory;
+  private VCFHeader header;
+
+  @Before
+  public void setup() throws Exception {
+    File partsDir = File.createTempFile("parts", "");
+    partsDir.delete();
+    partsDir.mkdir();
+    Files.createFile(new File(partsDir, "_SUCCESS").toPath());
+    partsDirectory = partsDir.toURI().toString();
+    header = VCFHeaderReader.readHeaderFrom(TestVCFHeaderReader.seekableStream("test.vcf"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testEmpty() throws IOException {
+    File out = File.createTempFile("out", ".vcf");
+    out.deleteOnExit();
+    VCFFileMerger.mergeParts(partsDirectory, out.toURI().toString(), header);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBCFNotSupported() throws IOException {
+    File out = File.createTempFile("out", ".bcf");
+    out.deleteOnExit();
+    Path target = Paths.get(URI.create(partsDirectory)).resolve("part-m-00000");
+    Files.copy(stream("test.uncompressed.bcf"), target);
+    VCFFileMerger.mergeParts(partsDirectory, out.toURI().toString(), header);
+  }
+
+  private InputStream stream(String resource) throws IOException {
+    return ClassLoader.getSystemClassLoader().getResource(resource).openStream();
+  }
+}

--- a/src/test/java/org/seqdoop/hadoop_bam/util/TestVCFHeaderReader.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/util/TestVCFHeaderReader.java
@@ -28,7 +28,7 @@ public class TestVCFHeaderReader {
     assertNotNull(VCFHeaderReader.readHeaderFrom(seekableStream("test.vcf.bgzf.gz")));
   }
 
-  private SeekableStream seekableStream(final String resource) throws IOException {
+  static SeekableStream seekableStream(final String resource) throws IOException {
     return new ByteArraySeekableStream(Resources.toByteArray(ClassLoader.getSystemClassLoader().getResource(resource)));
   }
 }


### PR DESCRIPTION
This moves code from GATK to Hadoop-BAM for merging sharded BAM or CRAM files. It also adds an option to write splitting BAM indexes from MR (defaults to off). The splitting indexes (if present) are merged into a single index as a part of the merge operation.