### PR TITLE
Handle FileSystemNotFoundException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
         <dependency>
             <groupId>com.github.jsr203hadoop</groupId>
             <artifactId>jsr203hadoop</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.3</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/org/seqdoop/hadoop_bam/BAMInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMInputFormat.java
@@ -37,6 +37,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
+import org.seqdoop.hadoop_bam.util.NIOFileUtil;
 import org.seqdoop.hadoop_bam.util.SAMHeaderReader;
 import org.seqdoop.hadoop_bam.util.WrapSeekable;
 
@@ -301,7 +302,8 @@ public class BAMInputFormat
 		}
 		for (Path bamFile : bamFiles) {
 			FileSystem fs = bamFile.getFileSystem(conf);
-			java.nio.file.Path index = SamFiles.findIndex(Paths.get(fs.makeQualified(bamFile).toUri()));
+			java.nio.file.Path index = SamFiles.findIndex(
+					NIOFileUtil.asPath(fs.makeQualified(bamFile).toUri()));
 			if (index == null) {
 				System.err.println("WARNING: no BAM index file found, splits will not be " +
 						"filtered, which may be very inefficient: " + bamFile);

--- a/src/main/java/org/seqdoop/hadoop_bam/CRAMRecordWriter.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/CRAMRecordWriter.java
@@ -15,6 +15,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
+import org.seqdoop.hadoop_bam.util.NIOFileUtil;
 import org.seqdoop.hadoop_bam.util.SAMHeaderReader;
 
 /** A base {@link RecordWriter} for CRAM records.
@@ -78,10 +79,10 @@ public abstract class CRAMRecordWriter<K>
         origOutput = output;
         this.writeHeader = writeHeader;
 
-        final URI referenceURI = URI.create(
-                ctx.getConfiguration().get(CRAMInputFormat.REFERENCE_SOURCE_PATH_PROPERTY)
-        );
-        refSource = new ReferenceSource(Paths.get(referenceURI));
+        final String referenceURI =
+                ctx.getConfiguration().get(CRAMInputFormat.REFERENCE_SOURCE_PATH_PROPERTY);
+        refSource = new ReferenceSource(referenceURI == null ? null :
+            NIOFileUtil.asPath(referenceURI));
 
         // A SAMFileHeader must be supplied at CRAMContainerStreamWriter creation time; if
         // we don't have one then delay creation until we do

--- a/src/main/java/org/seqdoop/hadoop_bam/util/SAMHeaderReader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/SAMHeaderReader.java
@@ -91,6 +91,6 @@ public final class SAMHeaderReader {
 		// configuration params, but it would break backward compatibility with existing code that
 		// is dependent on the CRAMInputFormat.REFERENCE_SOURCE_PATH_PROPERTY.
 		final String refSourcePath = conf.get(CRAMInputFormat.REFERENCE_SOURCE_PATH_PROPERTY);
-		return refSourcePath == null ? null : new ReferenceSource(Paths.get(URI.create(refSourcePath)));
+		return refSourcePath == null ? null : new ReferenceSource(NIOFileUtil.asPath(refSourcePath));
 	}
 }


### PR DESCRIPTION
This is needed when the filesystem provider is loaded using a URL classloader (e.g. in spark-submit).
