### PR TITLE
Improve performance for large interval lists

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <htsjdk.version>2.5.0</htsjdk.version>
+        <htsjdk.version>2.8.1</htsjdk.version>
         <!-- CHANGE THIS FOR A DIFFERENT VERSION OF HADOOP -->
         <hadoop.version>2.2.0</hadoop.version>
         <!--


### PR DESCRIPTION
Ignore the intervals for trimming/eliminating splits if there are more than a given number, specified by the property `hadoopbam.bam.max-intervals-for-split-filtering`, default 1000.

This addresses #91