### PR TITLE
Use htsjdk machinery to make reading with intervals significantly faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,7 @@ below:
 |`AnySAMInputFormat`|`hadoopbam.anysam.trust-exts`|`true`|Whether to detect the file format (BAM, SAM, or CRAM) by file extension. If `false`, use the file contents to detect the format.|
 |`KeyIgnoringAnySAMOutputFormat`|`hadoopbam.anysam.output-format`| |(Required.) The file format to use when writing BAM, SAM, or CRAM files. Should be one of `BAM`, `SAM`, or `CRAM`.|
 | |`hadoopbam.anysam.write-header`|`true`|Whether to write the SAM header in each output file part. If `true`, call `setSAMHeader()` or `readSAMHeaderFrom()` to set the desired header.|
-|`BAMInputFormat`|`hadoopbam.bam.keep-paired-reads-together`|`false`|If `true`, ensure that for paired reads both reads in a pair are always in the same split for queryname-sorted BAM files.|
-| |`hadoopbam.bam.intervals`| |Only include reads that match the specified intervals. Intervals are comma-separated and follow the same syntax as the `-L` option in SAMtools. E.g. `chr1:1-20000,chr2:12000-20000`.|
+|`BAMInputFormat`|`hadoopbam.bam.intervals`| |Only include reads that match the specified intervals. BAM files must be indexed in this case. Intervals are comma-separated and follow the same syntax as the `-L` option in SAMtools. E.g. `chr1:1-20000,chr2:12000-20000`.|
 |`KeyIgnoringBAMOutputFormat`|`hadoopbam.bam.write-splitting-bai`|`false`|If `true`, write _.splitting-bai_ files for every BAM file.|
 |`CRAMInputFormat`|`hadoopbam.cram.reference-source-path`| |(Required.) The path to the reference. May be an `hdfs://` path.|
 |`FastqInputFormat`|`hbam.fastq-input.base-quality-encoding`|`sanger`|The encoding used for base qualities. One of `sanger` or `illumina`.|

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <htsjdk.version>2.8.1</htsjdk.version>
+        <htsjdk.version>2.9.1</htsjdk.version>
         <!-- CHANGE THIS FOR A DIFFERENT VERSION OF HADOOP -->
         <hadoop.version>2.2.0</hadoop.version>
         <!--

--- a/src/main/java/org/seqdoop/hadoop_bam/VCFInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/VCFInputFormat.java
@@ -478,6 +478,7 @@ public class VCFInputFormat
 	}
 
 	private static boolean overlaps(long start, long end, long start2, long end2) {
-		return BAMInputFormat.overlaps(start, end, start2, end2);
+		return (start2 >= start && start2 <= end) || (end2 >=start && end2 <= end) ||
+				(start >= start2 && end <= end2);
 	}
 }


### PR DESCRIPTION
The main idea is to add the chunk intervals for each split into
the FileVirtualSplit class, so that each record reader can use
that information to only read the chunks in the BAM file that it
needs to, rather than read everything and apply filtering afterwards.

This change means that an index is always needed when using
intervals.

BAMRecordReader changes to use an iterator from SamReader, rather
than manage its own iteration (via BAMRecordCodec).

Support for keeping paired reads together in the same split has
been removed (previously set via
'hadoopbam.bam.keep-paired-reads-together'), since it is not
compatible with BAMFileReader managing the chunks to iterate over.
Applications that require this functionality can use the technique
in GATK's BwaSparkEngine#putPairsInSamePartition to achieve the
same result.