### PR TITLE
use log4j instead of System.err.printlns

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ can change the version of Hadoop linked against by modifying the
 corresponding parameter in the pom.xml build file.
 
 HTSJDK (formerly Picard SAM-JDK) Version 2.3.0 is required. Later versions
-may also work but have not been tested.
+may also work; Hadoop-BAM currently builds against 2.9.1.
 
 Availability:
 

--- a/pom.xml
+++ b/pom.xml
@@ -357,6 +357,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.25</version>
+        </dependency>
     </dependencies>
 
     <!-- The following shamelessly copied from ADAM -->

--- a/src/main/java/org/seqdoop/hadoop_bam/BAMInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMInputFormat.java
@@ -31,28 +31,12 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.Locatable;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
-import org.seqdoop.hadoop_bam.util.NIOFileUtil;
-import org.seqdoop.hadoop_bam.util.SAMHeaderReader;
-import org.seqdoop.hadoop_bam.util.WrapSeekable;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-
-import htsjdk.samtools.seekablestream.SeekableStream;
-
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -61,6 +45,18 @@ import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.seqdoop.hadoop_bam.util.NIOFileUtil;
+import org.seqdoop.hadoop_bam.util.SAMHeaderReader;
+import org.seqdoop.hadoop_bam.util.WrapSeekable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /** An {@link org.apache.hadoop.mapreduce.InputFormat} for BAM files. Values
  * are the individual records; see {@link BAMRecordReader} for the meaning of
@@ -97,7 +93,7 @@ public class BAMInputFormat
 		if (intervalsProperty == null) {
 			return null;
 		}
-		List<Interval> intervals = new ArrayList<Interval>();
+		List<Interval> intervals = new ArrayList<>();
 		for (String s : intervalsProperty.split(",")) {
 			String[] parts = s.split(":|-");
 			Interval interval =
@@ -138,15 +134,13 @@ public class BAMInputFormat
 		// addIndexedSplits() requires the given splits to be sorted by file
 		// path, so do so. Although FileInputFormat.getSplits() does, at the time
 		// of writing this, generate them in that order, we shouldn't rely on it.
-		Collections.sort(splits, new Comparator<InputSplit>() {
-			public int compare(InputSplit a, InputSplit b) {
-				FileSplit fa = (FileSplit)a, fb = (FileSplit)b;
-				return fa.getPath().compareTo(fb.getPath());
-			}
+		splits.sort((a, b) -> {
+			FileSplit fa = (FileSplit) a, fb = (FileSplit) b;
+			return fa.getPath().compareTo(fb.getPath());
 		});
 
 		final List<InputSplit> newSplits =
-			new ArrayList<InputSplit>(splits.size());
+			new ArrayList<>(splits.size());
 
 		for (int i = 0; i < splits.size();) {
 			try {
@@ -166,7 +160,7 @@ public class BAMInputFormat
 		throws IOException
 	{
 		final Path file = ((FileSplit)splits.get(i)).getPath();
-		List<InputSplit> potentialSplits = new ArrayList<InputSplit>();
+		List<InputSplit> potentialSplits = new ArrayList<>();
 
 		final SplittingBAMIndex idx = new SplittingBAMIndex(
 			file.getFileSystem(cfg).open(getIdxPath(file)));
@@ -208,9 +202,7 @@ public class BAMInputFormat
 						file, blockStart, blockEnd, fileSplit.getLocations()));
 		}
 
-		for (InputSplit s : potentialSplits) {
-			newSplits.add(s);
-		}
+		newSplits.addAll(potentialSplits);
 		return splitsEnd;
 	}
 

--- a/src/main/java/org/seqdoop/hadoop_bam/BAMInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMInputFormat.java
@@ -48,6 +48,8 @@ import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.seqdoop.hadoop_bam.util.NIOFileUtil;
 import org.seqdoop.hadoop_bam.util.SAMHeaderReader;
 import org.seqdoop.hadoop_bam.util.WrapSeekable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -65,8 +67,7 @@ import java.util.Set;
 public class BAMInputFormat
 	extends FileInputFormat<LongWritable,SAMRecordWritable>
 {
-	// set this to true for debug output
-	public final static boolean DEBUG_BAM_SPLITTER = false;
+	private Logger logger = LoggerFactory.getLogger(BAMInputFormat.class);
 
 	/**
 	 * Filter by region, like <code>-L</code> in SAMtools. Takes a comma-separated
@@ -192,8 +193,7 @@ public class BAMInputFormat
 			}
 
 			if (blockStart == null || blockEnd == null) {
-				System.err.println("Warning: index for " + file.toString() +
-						" was not good. Generating probabilistic splits.");
+				logger.warn("Index for {} was not good. Generating probabilistic splits", file);
 
 				return addProbabilisticSplits(splits, i, newSplits, cfg);
 			}
@@ -256,12 +256,13 @@ public class BAMInputFormat
 			} else {
 				previousSplit = new FileVirtualSplit(
                                         path, alignedBeg, alignedEnd, fspl.getLocations());
-				if(DEBUG_BAM_SPLITTER) {	
+				if(logger.isDebugEnabled()) {
 					final long byte_offset  = alignedBeg >>> 16;
                                 	final long record_offset = alignedBeg & 0xffff;
-					System.err.println("XXX split " + i +
-						" byte offset: " + byte_offset + " record offset: " + 
-						record_offset + " virtual offset: " + alignedBeg);
+					logger.debug(
+						"Split {}: byte offset: {}, record offset: {}, virtual offset: {}",
+						i , byte_offset, record_offset, alignedBeg
+					);
 				}
 				newSplits.add(previousSplit);
 			}

--- a/src/main/java/org/seqdoop/hadoop_bam/BAMRecordReader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMRecordReader.java
@@ -34,7 +34,6 @@ import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.Interval;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;

--- a/src/main/java/org/seqdoop/hadoop_bam/BAMRecordReader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMRecordReader.java
@@ -53,6 +53,8 @@ import org.seqdoop.hadoop_bam.util.MurmurHash3;
 import org.seqdoop.hadoop_bam.util.NIOFileUtil;
 import org.seqdoop.hadoop_bam.util.SAMHeaderReader;
 import org.seqdoop.hadoop_bam.util.WrapSeekable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** The key is the bitwise OR of the reference sequence ID in the upper 32 bits
  * and the 0-based leftmost coordinate in the lower.
@@ -69,6 +71,8 @@ public class BAMRecordReader
 	private long fileStart;
 	private long virtualEnd;
 	private boolean isInitialized = false;
+
+	private Logger logger = LoggerFactory.getLogger(BAMRecordReader.class);
 
 	/** Note: this is the only getKey function that handles unmapped reads
 	 * specially!
@@ -152,10 +156,9 @@ public class BAMRecordReader
 				((SamReader.PrimitiveSamReaderToSamReaderAdapter) samReader).underlyingReader();
 		BAMFileReader bamFileReader = (BAMFileReader) primitiveSamReader;
 
-		if(BAMInputFormat.DEBUG_BAM_SPLITTER) {
+		if(logger.isDebugEnabled()) {
 			final long recordStart = virtualStart & 0xffff;
-                	System.err.println("XXX inizialized BAMRecordReader byte offset: " +
-				fileStart + " record offset: " + recordStart);
+			logger.debug("Initialized BAMRecordReader; byte offset: {}, record offset: {}", fileStart, recordStart);
 		}
 
 		if (conf.getBoolean("hadoopbam.bam.keep-paired-reads-together", false)) {

--- a/src/main/java/org/seqdoop/hadoop_bam/FastaInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/FastaInputFormat.java
@@ -155,7 +155,7 @@ public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 						origsplit.getLocations()
 					);
 
-				newSplits.add(fsplit); //conf));
+				newSplits.add(fsplit);
 				logger.debug("adding split: {}", fsplit);
 				break;
 			}
@@ -193,7 +193,6 @@ public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 
 		public FastaRecordReader(Configuration conf, FileSplit split) throws IOException
 		{
-			setConf(conf);
 			file = split.getPath();
 			start = split.getStart();
 			end = start + split.getLength();
@@ -250,10 +249,6 @@ public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 			start = start + bytesRead;
 			stream.seek(start);
 			pos = start;
-		}
-
-		protected void setConf(Configuration conf)
-		{
 		}
 
 		/**

--- a/src/main/java/org/seqdoop/hadoop_bam/FastaInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/FastaInputFormat.java
@@ -56,96 +56,119 @@ public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 {
 	public static final Charset UTF8 = Charset.forName("UTF8");
 
-    @Override public List<InputSplit> getSplits(JobContext job) throws IOException
+	@Override public List<InputSplit> getSplits(JobContext job) throws IOException
 	{
 
-	    // Note: We generate splits that correspond to different sections in the FASTA
-	    // input (which here are called "chromosomes", delimited by '>' and
-	    // followed by a single line description.
-	    // Some locality is preserved since the locations are formed from the input
-	    // splits, although no special attention is given to this issues (FASTA files
-	    // are assumed to be smallish).
-	    // The splits are generated on the client. In the future the split generation
-	    // should be only performed once and an index file stored inside HDFS for
-	    // peformance reasons. Currently this is not attempted (again: FASTA files
-	    // aren't all that big).
+		// Note: We generate splits that correspond to different sections in the FASTA
+		// input (which here are called "chromosomes", delimited by '>' and
+		// followed by a single line description.
+		// Some locality is preserved since the locations are formed from the input
+		// splits, although no special attention is given to this issues (FASTA files
+		// are assumed to be smallish).
+		// The splits are generated on the client. In the future the split generation
+		// should be only performed once and an index file stored inside HDFS for
+		// peformance reasons. Currently this is not attempted (again: FASTA files
+		// aren't all that big).
 
-	    // we first make sure we are given only a single file
+		// we first make sure we are given only a single file
 
-            List<InputSplit> splits = super.getSplits(job);
-            
-            // first sort by input path
-            Collections.sort(splits, new Comparator<InputSplit>()
-                             {
-                                 public int compare(InputSplit a, InputSplit b) {
-                                     FileSplit fa = (FileSplit)a, fb = (FileSplit)b;
-                                     return fa.getPath().compareTo(fb.getPath());
-                                 }
-                             });
+		List<InputSplit> splits = super.getSplits(job);
 
-            for (int i = 0; i < splits.size()-1; i++) {
-                FileSplit fa = (FileSplit)splits.get(i);
-                FileSplit fb = (FileSplit)splits.get(i+1);
-                    
-                if(fa.getPath().compareTo(fb.getPath()) != 0)
-                    throw new IOException("FastaInputFormat assumes single FASTA input file!");
-            }
-
-            // now we are sure we only have one FASTA input file
-
-	    final List<InputSplit> newSplits = new ArrayList<InputSplit>(splits.size());
-	    FileSplit fileSplit = (FileSplit)splits.get(0);
-	    Path path = fileSplit.getPath();
-
-	    FileSystem fs = path.getFileSystem(job.getConfiguration());
-	    FSDataInputStream fis = fs.open(path);
-	    byte[] buffer = new byte[1024];
-
-	    long byte_counter = 0;
-	    long prev_chromosome_byte_offset = 0;
-	    boolean first_chromosome = true;
-
-	    for(int j = 0; j < splits.size(); j++) {
-		FileSplit origsplit = (FileSplit)splits.get(j);
-
-		while(byte_counter < origsplit.getStart()+origsplit.getLength()) {
-		    long bytes_read = fis.read(byte_counter, buffer, 0, (int)Math.min(buffer.length,
-										      origsplit.getStart()+origsplit.getLength()- byte_counter));
-		    //System.err.println("bytes_read: "+Integer.toString((int)bytes_read)+" of "+Integer.toString(splits.size())+" splits");
-		    if(bytes_read > 0) {
-			for(int i=0;i<bytes_read;i++) {
-			    if(buffer[i] == (byte)'>') {
-				//System.err.println("found chromosome at position "+Integer.toString((int)byte_counter+i));
-				
-				if(!first_chromosome) {
-				    FileSplit fsplit = new FileSplit(path, prev_chromosome_byte_offset, byte_counter + i-1 - prev_chromosome_byte_offset, origsplit.getLocations());
-				    //System.err.println("adding split: start: "+Integer.toString((int)fsplit.getStart())+" length: "+Integer.toString((int)fsplit.getLength()));
-				    
-				    newSplits.add(fsplit);
-				}
-				first_chromosome = false;
-				prev_chromosome_byte_offset = byte_counter + i;
-			    }
+		// first sort by input path
+		Collections.sort(splits, new Comparator<InputSplit>()
+		{
+			public int compare(InputSplit a, InputSplit b) {
+				FileSplit fa = (FileSplit)a, fb = (FileSplit)b;
+				return fa.getPath().compareTo(fb.getPath());
 			}
-			byte_counter += bytes_read;
-		    }
+		});
+
+		for (int i = 0; i < splits.size()-1; i++) {
+			FileSplit fa = (FileSplit)splits.get(i);
+			FileSplit fb = (FileSplit)splits.get(i+1);
+
+			if(fa.getPath().compareTo(fb.getPath()) != 0)
+				throw new IOException("FastaInputFormat assumes single FASTA input file!");
 		}
 
-		if(j == splits.size()-1) {
-		    //System.err.println("EOF");
-		    FileSplit fsplit = new FileSplit(path, prev_chromosome_byte_offset, byte_counter - prev_chromosome_byte_offset, origsplit.getLocations());
-		    newSplits.add(fsplit); //conf));
-		    //System.err.println("adding split: "+fsplit.toString());
-		    break;
+		// now we are sure we only have one FASTA input file
+
+		final List<InputSplit> newSplits = new ArrayList<InputSplit>(splits.size());
+		FileSplit fileSplit = (FileSplit)splits.get(0);
+		Path path = fileSplit.getPath();
+
+		FileSystem fs = path.getFileSystem(job.getConfiguration());
+		FSDataInputStream fis = fs.open(path);
+		byte[] buffer = new byte[1024];
+
+		long byte_counter = 0;
+		long prev_chromosome_byte_offset = 0;
+		boolean first_chromosome = true;
+
+		for(int j = 0; j < splits.size(); j++) {
+			FileSplit origsplit = (FileSplit)splits.get(j);
+
+			while(byte_counter < origsplit.getStart()+origsplit.getLength()) {
+				long bytes_read =
+					fis.read(
+						byte_counter,
+						buffer,
+						0,
+						Math.min(
+							buffer.length,
+							(int) (origsplit.getStart()+origsplit.getLength() - byte_counter)
+						)
+					);
+
+				//System.err.println("bytes_read: "+Integer.toString((int)bytes_read)+" of "+Integer.toString(splits.size())+" splits");
+				if(bytes_read > 0) {
+					for(int i=0;i<bytes_read;i++) {
+						if(buffer[i] == (byte)'>') {
+							//System.err.println("found chromosome at position "+Integer.toString((int)byte_counter+i));
+
+							if(!first_chromosome) {
+								FileSplit fsplit =
+									new FileSplit(
+										path,
+										prev_chromosome_byte_offset,
+										byte_counter + i-1 - prev_chromosome_byte_offset,
+										origsplit.getLocations()
+									);
+
+								//System.err.println("adding split: start: "+Integer.toString((int)fsplit.getStart())+" length: "+Integer.toString((int)fsplit.getLength()));
+
+								newSplits.add(fsplit);
+							}
+							first_chromosome = false;
+							prev_chromosome_byte_offset = byte_counter + i;
+						}
+					}
+					byte_counter += bytes_read;
+				}
+			}
+
+			if(j == splits.size()-1) {
+				//System.err.println("EOF");
+				FileSplit fsplit =
+					new FileSplit(
+						path,
+						prev_chromosome_byte_offset,
+						byte_counter - prev_chromosome_byte_offset,
+						origsplit.getLocations()
+					);
+
+				newSplits.add(fsplit); //conf));
+				//System.err.println("adding split: "+fsplit.toString());
+				break;
+			}
 		}
-	    }
-	    
-	    return newSplits;
+
+		return newSplits;
 	}
 
 	public static class FastaRecordReader extends RecordReader<Text,ReferenceFragment>
 	{
-		
+
 		// start:  first valid data index
 		private long start;
 		// end:  first index value beyond the slice, i.e. slice is in range [start,end)
@@ -206,29 +229,29 @@ public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 		 */
 		private void positionAtFirstRecord(FSDataInputStream stream) throws IOException
 		{
-		    if (start > 0)
+			if (start > 0)
 			{
-			    stream.seek(start);
+				stream.seek(start);
 			}
 
-		    // we are now in a new chromosome/fragment, so read its name/index sequence
-		    // and reset position counter
+			// we are now in a new chromosome/fragment, so read its name/index sequence
+			// and reset position counter
 
-		    // index sequence
-		    LineReader reader = new LineReader(stream);
-		    int bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
+			// index sequence
+			LineReader reader = new LineReader(stream);
+			int bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
 
-		    current_split_indexseq = buffer.toString();
-		    // now get rid of '>' character
-		    current_split_indexseq = current_split_indexseq.substring(1,current_split_indexseq.length());
-		    
-		    // initialize position counter
-		    current_split_pos = 1;
-		    
-		    //System.err.println("read index sequence: "+current_split_indexseq);
-		    start = start + bytesRead;
-		    stream.seek(start);
-		    pos = start;
+			current_split_indexseq = buffer.toString();
+			// now get rid of '>' character
+			current_split_indexseq = current_split_indexseq.substring(1,current_split_indexseq.length());
+
+			// initialize position counter
+			current_split_pos = 1;
+
+			//System.err.println("read index sequence: "+current_split_indexseq);
+			start = start + bytesRead;
+			stream.seek(start);
+			pos = start;
 		}
 
 		protected void setConf(Configuration conf)
@@ -254,7 +277,7 @@ public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 		 * Added to use mapreduce API.
 		 */
 		public ReferenceFragment getCurrentValue()
-	 	{
+		{
 			return currentValue;
 		}
 
@@ -340,23 +363,23 @@ public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 
 		private void scanFastaLine(Text line, Text key, ReferenceFragment fragment)
 		{
-		    // Build the key.  We concatenate the chromosome/fragment descripion and
-		    // the start position of the FASTA sequence line, replacing the tabs with colons.
-		    key.clear();
-		    
-		    key.append(current_split_indexseq.getBytes(UTF8), 0, current_split_indexseq.getBytes(UTF8).length);
-		    key.append(Integer.toString(current_split_pos).getBytes(UTF8), 0, Integer.toString(current_split_pos).getBytes(UTF8).length);
-		    // replace tabs with :
-		    byte[] bytes = key.getBytes();
-		    int temporaryEnd = key.getLength();
-		    for (int i = 0; i < temporaryEnd; ++i)
-			if (bytes[i] == '\t')
-			    bytes[i] = ':';
-		    
-		    fragment.clear();
-		    fragment.setPosition(current_split_pos);
-		    fragment.setIndexSequence(current_split_indexseq);
-		    fragment.getSequence().append(line.getBytes(), 0, line.getBytes().length);
+			// Build the key.  We concatenate the chromosome/fragment descripion and
+			// the start position of the FASTA sequence line, replacing the tabs with colons.
+			key.clear();
+
+			key.append(current_split_indexseq.getBytes(UTF8), 0, current_split_indexseq.getBytes(UTF8).length);
+			key.append(Integer.toString(current_split_pos).getBytes(UTF8), 0, Integer.toString(current_split_pos).getBytes(UTF8).length);
+			// replace tabs with :
+			byte[] bytes = key.getBytes();
+			int temporaryEnd = key.getLength();
+			for (int i = 0; i < temporaryEnd; ++i)
+				if (bytes[i] == '\t')
+					bytes[i] = ':';
+
+			fragment.clear();
+			fragment.setPosition(current_split_pos);
+			fragment.setIndexSequence(current_split_indexseq);
+			fragment.getSequence().append(line.getBytes(), 0, line.getBytes().length);
 		}
 	}
 
@@ -368,8 +391,9 @@ public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 	}
 
 	public RecordReader<Text, ReferenceFragment> createRecordReader(
-	                                        InputSplit genericSplit,
-	                                        TaskAttemptContext context) throws IOException, InterruptedException
+		InputSplit genericSplit,
+		TaskAttemptContext context)
+		throws IOException, InterruptedException
 	{
 		context.setStatus(genericSplit.toString());
 		return new FastaRecordReader(context.getConfiguration(), (FileSplit)genericSplit); // cast as per example in TextInputFormat

--- a/src/main/java/org/seqdoop/hadoop_bam/FastaInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/FastaInputFormat.java
@@ -26,8 +26,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
@@ -75,12 +73,9 @@ public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 		List<InputSplit> splits = super.getSplits(job);
 
 		// first sort by input path
-		Collections.sort(splits, new Comparator<InputSplit>()
-		{
-			public int compare(InputSplit a, InputSplit b) {
-				FileSplit fa = (FileSplit)a, fb = (FileSplit)b;
-				return fa.getPath().compareTo(fb.getPath());
-			}
+		splits.sort((a, b) -> {
+			FileSplit fa = (FileSplit) a, fb = (FileSplit) b;
+			return fa.getPath().compareTo(fb.getPath());
 		});
 
 		for (int i = 0; i < splits.size()-1; i++) {
@@ -93,7 +88,7 @@ public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 
 		// now we are sure we only have one FASTA input file
 
-		final List<InputSplit> newSplits = new ArrayList<InputSplit>(splits.size());
+		final List<InputSplit> newSplits = new ArrayList<>(splits.size());
 		FileSplit fileSplit = (FileSplit)splits.get(0);
 		Path path = fileSplit.getPath();
 

--- a/src/main/java/org/seqdoop/hadoop_bam/FastaInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/FastaInputFormat.java
@@ -41,6 +41,8 @@ import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Reads the FASTA reference sequence format.
@@ -52,6 +54,8 @@ import org.apache.hadoop.mapreduce.lib.input.FileSplit;
  */
 public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 {
+	private static Logger logger = LoggerFactory.getLogger(FastaInputFormat.class);
+
 	public static final Charset UTF8 = Charset.forName("UTF8");
 
 	@Override public List<InputSplit> getSplits(JobContext job) throws IOException
@@ -115,11 +119,11 @@ public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 						)
 					);
 
-				//System.err.println("bytes_read: "+Integer.toString((int)bytes_read)+" of "+Integer.toString(splits.size())+" splits");
+				logger.debug("bytes_read: {} of {} splits", bytes_read, splits.size());
 				if(bytes_read > 0) {
 					for(int i=0;i<bytes_read;i++) {
 						if(buffer[i] == (byte)'>') {
-							//System.err.println("found chromosome at position "+Integer.toString((int)byte_counter+i));
+							logger.debug("found chromosome at position {}", byte_counter + i);
 
 							if(!first_chromosome) {
 								FileSplit fsplit =
@@ -130,7 +134,7 @@ public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 										origsplit.getLocations()
 									);
 
-								//System.err.println("adding split: start: "+Integer.toString((int)fsplit.getStart())+" length: "+Integer.toString((int)fsplit.getLength()));
+								logger.debug("adding split: start: {} length: {}", fsplit.getStart(), fsplit.getLength());
 
 								newSplits.add(fsplit);
 							}
@@ -143,7 +147,6 @@ public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 			}
 
 			if(j == splits.size()-1) {
-				//System.err.println("EOF");
 				FileSplit fsplit =
 					new FileSplit(
 						path,
@@ -153,7 +156,7 @@ public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 					);
 
 				newSplits.add(fsplit); //conf));
-				//System.err.println("adding split: "+fsplit.toString());
+				logger.debug("adding split: {}", fsplit);
 				break;
 			}
 		}
@@ -243,7 +246,7 @@ public class FastaInputFormat extends FileInputFormat<Text,ReferenceFragment>
 			// initialize position counter
 			current_split_pos = 1;
 
-			//System.err.println("read index sequence: "+current_split_indexseq);
+			logger.debug("read index sequence: {}");
 			start = start + bytesRead;
 			stream.seek(start);
 			pos = start;

--- a/src/main/java/org/seqdoop/hadoop_bam/VCFInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/VCFInputFormat.java
@@ -32,7 +32,6 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -103,7 +102,7 @@ public class VCFInputFormat
 		if (intervalsProperty == null) {
 			return null;
 		}
-		List<Interval> intervals = new ArrayList<Interval>();
+		List<Interval> intervals = new ArrayList<>();
 		for (String s : intervalsProperty.split(",")) {
 			String[] parts = s.split(":|-");
 			Interval interval =
@@ -133,7 +132,7 @@ public class VCFInputFormat
 	 * <code>Job.setInputFormatClass</code>.
 	 */
 	public VCFInputFormat() {
-		this.formatMap = new HashMap<Path,VCFFormat>();
+		this.formatMap = new HashMap<>();
 		this.givenMap  = false;
 		this.conf      = null;
 	}
@@ -142,7 +141,7 @@ public class VCFInputFormat
 	 * the given <code>Configuration</code>.
 	 */
 	public VCFInputFormat(Configuration conf) {
-		this.formatMap = new HashMap<Path,VCFFormat>();
+		this.formatMap = new HashMap<>();
 		this.conf      = conf;
 		this.trustExts = conf.getBoolean(TRUST_EXTS_PROPERTY, true);
 		this.givenMap  = false;
@@ -288,9 +287,9 @@ public class VCFInputFormat
 		// over to getBCFSplits().
 
 		final List<FileSplit>
-			bcfOrigSplits = new ArrayList<FileSplit>(origSplits.size());
+			bcfOrigSplits = new ArrayList<>(origSplits.size());
 		final List<InputSplit>
-			newSplits     = new ArrayList<InputSplit>(origSplits.size());
+			newSplits     = new ArrayList<>(origSplits.size());
 
 		for (final InputSplit iSplit : origSplits) {
 			final FileSplit split = (FileSplit)iSplit;
@@ -314,11 +313,7 @@ public class VCFInputFormat
 		// addGuessedSplits() requires the given splits to be sorted by file
 		// path, so do so. Although FileInputFormat.getSplits() does, at the time
 		// of writing this, generate them in that order, we shouldn't rely on it.
-		Collections.sort(splits, new Comparator<FileSplit>() {
-			public int compare(FileSplit a, FileSplit b) {
-				return a.getPath().compareTo(b.getPath());
-			}
-		});
+		splits.sort(Comparator.comparing(FileSplit::getPath));
 
 		for (int i = 0; i < splits.size();)
 			i = addGuessedSplits(splits, i, newSplits);
@@ -399,7 +394,7 @@ public class VCFInputFormat
 			return splits;
 		}
 		List<Block> blocks = new ArrayList<>();
-		Set<Path> vcfFiles = new LinkedHashSet<Path>();
+		Set<Path> vcfFiles = new LinkedHashSet<>();
 		for (InputSplit split : splits) {
 			if (split instanceof FileSplit) {
 				vcfFiles.add(((FileSplit) split).getPath());
@@ -431,7 +426,7 @@ public class VCFInputFormat
 		}
 
 		// Use the blocks to filter the splits
-		List<InputSplit> filteredSplits = new ArrayList<InputSplit>();
+		List<InputSplit> filteredSplits = new ArrayList<>();
 		for (InputSplit split : splits) {
 			if (split instanceof FileSplit) {
 				FileSplit fileSplit = (FileSplit) split;

--- a/src/main/java/org/seqdoop/hadoop_bam/util/VCFFileMerger.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/VCFFileMerger.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.zip.GZIPOutputStream;
 import org.seqdoop.hadoop_bam.KeyIgnoringVCFOutputFormat;
 import org.seqdoop.hadoop_bam.VCFFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.seqdoop.hadoop_bam.util.NIOFileUtil.asPath;
 import static org.seqdoop.hadoop_bam.util.NIOFileUtil.deleteRecursive;
@@ -29,6 +31,9 @@ import static org.seqdoop.hadoop_bam.util.NIOFileUtil.mergeInto;
  * into a single file. BCF files are not supported.
  */
 public class VCFFileMerger {
+
+  private static Logger logger = LoggerFactory.getLogger(VCFFileMerger.class);
+
   /**
    * Merge part file shards produced by {@link KeyIgnoringVCFOutputFormat} into a
    * single file with the given header.
@@ -85,11 +90,9 @@ public class VCFFileMerger {
     boolean blockCompressed = isBlockCompressed(parts);
     boolean bgzExtension = outputPath.toString().endsWith(BGZFCodec.DEFAULT_EXTENSION);
     if (blockCompressed && !bgzExtension) {
-      System.err.println("WARNING: parts are block compressed, but output does not " +
-          "have .bgz extension: " + outputPath);
+      logger.warn("Parts are block compressed, but output does not have .bgz extension: {}", outputPath);
     } else if (!blockCompressed && bgzExtension) {
-      System.err.println("WARNING: parts are not block compressed, but output has a " +
-          ".bgz extension: " + outputPath);
+      logger.warn("WARNING: parts are not block compressed, but output has a .bgz extension: {}", outputPath);
     }
     boolean gzipCompressed = isGzipCompressed(parts);
     OutputStream headerOut;

--- a/src/main/java/org/seqdoop/hadoop_bam/util/VCFHeaderReader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/VCFHeaderReader.java
@@ -39,11 +39,16 @@ import htsjdk.variant.vcf.VCFCodec;
 import htsjdk.variant.vcf.VCFHeader;
 import java.util.zip.GZIPInputStream;
 import org.seqdoop.hadoop_bam.VCFFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Can read a VCF header without being told beforehand whether the input is
  * VCF or BCF.
  */
 public final class VCFHeaderReader {
+
+	private static Logger logger = LoggerFactory.getLogger(VCFHeaderReader.class);
+
 	public static VCFHeader readHeaderFrom(final SeekableStream in)
 		throws IOException
 	{
@@ -55,7 +60,7 @@ public final class VCFHeaderReader {
 			InputStream is = VCFFormat.isGzip(bis) ? new GZIPInputStream(bis) : bis;
 			headerCodec = new VCFCodec().readHeader(new AsciiLineReaderIterator(new AsciiLineReader(is)));
 		} catch (TribbleException e) {
-            System.err.println("warning: while trying to read VCF header from file received exception: "+e.toString());
+			logger.warn("Exception while trying to read VCF header from file:", e);
 
 			in.seek(initialPos);
 

--- a/src/main/java/org/seqdoop/hadoop_bam/util/VCFHeaderReader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/VCFHeaderReader.java
@@ -47,7 +47,7 @@ public final class VCFHeaderReader {
 	public static VCFHeader readHeaderFrom(final SeekableStream in)
 		throws IOException
 	{
-		Object headerCodec = null;
+		FeatureCodecHeader headerCodec;
         Object header = null;
 		final long initialPos = in.position();
 		try {
@@ -67,9 +67,11 @@ public final class VCFHeaderReader {
 				new BCF2Codec().readHeader(
 					new PositionalBufferedStream(bin));
 		}
-		if (!(headerCodec instanceof FeatureCodecHeader))
+
+		if (!(headerCodec != null))
 			throw new IOException("No VCF header found");
-        header = ((FeatureCodecHeader)headerCodec).getHeaderValue();
+
+        header = headerCodec.getHeaderValue();
 		return (VCFHeader)header;
 	}
 }

--- a/src/test/java/org/seqdoop/hadoop_bam/TestQseqInputFormat.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestQseqInputFormat.java
@@ -23,8 +23,6 @@
 package org.seqdoop.hadoop_bam;
 
 import org.seqdoop.hadoop_bam.QseqInputFormat.QseqRecordReader;
-import org.seqdoop.hadoop_bam.SequencedFragment;
-import org.seqdoop.hadoop_bam.FormatException;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,8 +36,6 @@ import org.junit.*;
 import static org.junit.Assert.*;
 
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.compress.GzipCodec;
 import org.apache.hadoop.io.Text;
@@ -202,7 +198,7 @@ public class TestQseqInputFormat
 		assertEquals(1000, fragment.getXpos().intValue());
 		assertEquals(12850, fragment.getYpos().intValue());
 		assertEquals(1, fragment.getRead().intValue());
-		assertEquals(false, fragment.getFilterPassed().booleanValue());
+		assertEquals(false, fragment.getFilterPassed());
 		assertNull("control number not null", fragment.getControlNumber());
 		assertEquals("ATCACG", fragment.getIndexSequence());
 	}
@@ -285,14 +281,14 @@ public class TestQseqInputFormat
 	public void testCreateKey() throws IOException
 	{
 		QseqRecordReader reader = createReaderForOneQseq();
-		assertTrue(reader.createKey() instanceof Text);
+		assertTrue(reader.createKey() != null);
 	}
 
 	@Test
 	public void testCreateValue() throws IOException
 	{
 		QseqRecordReader reader = createReaderForOneQseq();
-		assertTrue(reader.createValue() instanceof SequencedFragment);
+		assertTrue(reader.createValue() != null);
 	}
 
 	@Test
@@ -348,8 +344,9 @@ public class TestQseqInputFormat
 
 		// now try to read it starting from the middle
 		split = new FileSplit(new Path(tempGz.toURI().toString()), 10, twoQseq.length(), null);
-		QseqRecordReader reader = new QseqRecordReader(conf, split);
+		new QseqRecordReader(conf, split);
 	}
+
 	@Test
 	public void testSkipFailedQC() throws IOException
 	{

--- a/src/test/java/org/seqdoop/hadoop_bam/TestQseqInputFormat.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestQseqInputFormat.java
@@ -128,7 +128,7 @@ public class TestQseqInputFormat
 
 		boolean retval = reader.next(key, fragment);
 		assertTrue(retval);
-//System.err.println("in testReadFromStart quality: " + fragment.getQuality().toString());
+
 		assertEquals("ERR020229:10880:1:1:1373:2042:1", key.toString());
 		assertEquals("TTGGATGATAGGGATTATTTGACTCGAATATTGGAAATAGCTGTTTATATTTTTTAAAAATGGTCTGTAACTGGTGACAGGACGCTTCGAT", fragment.getSequence().toString());
 		assertEquals("###########################################################################################", fragment.getQuality().toString());

--- a/src/test/java/org/seqdoop/hadoop_bam/TestQseqInputFormat.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestQseqInputFormat.java
@@ -281,14 +281,14 @@ public class TestQseqInputFormat
 	public void testCreateKey() throws IOException
 	{
 		QseqRecordReader reader = createReaderForOneQseq();
-		assertTrue(reader.createKey() != null);
+		assertNotNull(reader.createKey());
 	}
 
 	@Test
 	public void testCreateValue() throws IOException
 	{
 		QseqRecordReader reader = createReaderForOneQseq();
-		assertTrue(reader.createValue() != null);
+		assertNotNull(reader.createValue());
 	}
 
 	@Test

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,5 +1,7 @@
-log4j.rootLogger = INFO, out
+log4j.rootLogger = ERROR, out
 
 log4j.appender.out = org.apache.log4j.ConsoleAppender
 log4j.appender.out.layout = org.apache.log4j.PatternLayout
 log4j.appender.out.layout.ConversionPattern = %d (%t) [%p - %l] %m%n
+
+log4j.logger.org.seqdoop.hadoop_bam=DEBUG


### PR DESCRIPTION
- `DEBUG_BAM_SPLITTER` flag → `logger.{isDebugEnabled,debug}`
- default test logging: `ERROR` for all dependencies, `DEBUG` for hadoop_bam package
- miscellaneous indentation and intellij-recommended style nits
- rm unused/misleading no-op `FastaInputFormat.setConf` method