### PR TITLE
Catch ProviderNotFoundException when picking BAM splits, and formally…

### DIFF
--- a/src/main/java/org/seqdoop/hadoop_bam/BAMInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMInputFormat.java
@@ -50,6 +50,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.file.ProviderNotFoundException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -191,7 +192,7 @@ public class BAMInputFormat
 	/** Returns a {@link BAMRecordReader} initialized with the parameters. */
 	@Override public RecordReader<LongWritable,SAMRecordWritable>
 		createRecordReader(InputSplit split, TaskAttemptContext ctx)
-			throws InterruptedException, IOException
+            throws InterruptedException, IOException
 	{
 		final RecordReader<LongWritable,SAMRecordWritable> rr =
 			new BAMRecordReader();
@@ -231,7 +232,7 @@ public class BAMInputFormat
 		for (int i = 0; i < origSplits.size();) {
 			try {
 				i = addIndexedSplits      (origSplits, i, newSplits, cfg);
-			} catch (IOException e) {
+			} catch (IOException | ProviderNotFoundException e) {
 				i = addProbabilisticSplits(origSplits, i, newSplits, cfg);
 			}
 		}

--- a/src/main/java/org/seqdoop/hadoop_bam/BAMRecordReader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMRecordReader.java
@@ -120,7 +120,7 @@ public class BAMRecordReader
 	}
 
 	@Override public void initialize(InputSplit spl, TaskAttemptContext ctx)
-		throws IOException
+            throws IOException
 	{
 		// This method should only be called once (see Hadoop API). However,
 		// there seems to be disagreement between implementations that call


### PR DESCRIPTION
… throw it from the RecordReader. Resolves #125.