### PR TITLE
Add codepath to calculate splits from BAM index.

### DIFF
--- a/src/main/java/htsjdk/samtools/LinearBAMIndex.java
+++ b/src/main/java/htsjdk/samtools/LinearBAMIndex.java
@@ -1,0 +1,39 @@
+// Copyright (c) 2017
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+package htsjdk.samtools;
+
+import htsjdk.samtools.CachingBAMFileIndex;
+import htsjdk.samtools.LinearIndex;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.seekablestream.SeekableStream;
+
+/**
+ * The htsjdk APIs for accessing the linear BAM index are private...
+ */
+public class LinearBAMIndex extends CachingBAMFileIndex {
+
+        public LinearBAMIndex(SeekableStream stream, SAMSequenceDictionary dict) {
+                super(stream, dict);
+        }
+        
+        public LinearIndex getLinearIndex(int idx) {
+                return getQueryResults(idx).getLinearIndex();
+        }
+}


### PR DESCRIPTION
This is pretty ugly right now (see debugging statements, commented out code, etc), but this code adds a path to identify splits from a BAM file using the BAM index on disk. It does this by using the linear index that accompanies the BAM file to identify the first block in the linear index that starts after the start/end of a suggested split. This code works (for a single indexed file, haven't tested multiple files yet) and appears to show modest performance improvements in split discovery.

As an aside, while the `htsjdk.samtools.LinearIndex` class is public, there doesn't appear to be a public way to access a `LinearIndex`, so I've added the cruddy `LinearBAMIndex` class.

As said earlier, this code is very WIP, but I wanted to push it early to get general comments on the strategy, and to start a conversation about where this might fit in, relative to the splitting BAI code.