### PR TITLE
Upgrade to htsjdk 2.11.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <htsjdk.version>2.9.1</htsjdk.version>
+        <htsjdk.version>2.11.0</htsjdk.version>
         <!-- CHANGE THIS FOR A DIFFERENT VERSION OF HADOOP -->
         <hadoop.version>2.2.0</hadoop.version>
         <!--

--- a/src/test/java/org/seqdoop/hadoop_bam/TestBAMInputFormat.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestBAMInputFormat.java
@@ -56,8 +56,8 @@ public class TestBAMInputFormat {
     assertEquals(2, splits.size());
     List<SAMRecord> split0Records = getSAMRecordsFromSplit(inputFormat, splits.get(0));
     List<SAMRecord> split1Records = getSAMRecordsFromSplit(inputFormat, splits.get(1));
-    assertEquals(1629, split0Records.size());
-    assertEquals(371, split1Records.size());
+    assertEquals(1577, split0Records.size());
+    assertEquals(423, split1Records.size());
     SAMRecord lastRecordOfSplit0 = split0Records.get(split0Records.size() - 1);
     SAMRecord firstRecordOfSplit1 = split1Records.get(0);
     assertEquals(lastRecordOfSplit0.getReadName(), firstRecordOfSplit1.getReadName());
@@ -98,8 +98,8 @@ public class TestBAMInputFormat {
     assertEquals(2, splits.size());
     List<SAMRecord> split0Records = getSAMRecordsFromSplit(inputFormat, splits.get(0));
     List<SAMRecord> split1Records = getSAMRecordsFromSplit(inputFormat, splits.get(1));
-    assertEquals(1629, split0Records.size());
-    assertEquals(371, split1Records.size());
+    assertEquals(1577, split0Records.size());
+    assertEquals(423, split1Records.size());
   }
 
   private List<SAMRecord> getSAMRecordsFromSplit(BAMInputFormat inputFormat,


### PR DESCRIPTION
Unit test fixes are due to this change in htsjdk: https://github.com/samtools/htsjdk/pull/692,
which presumably changes the record boundaries.