### PR TITLE
Improve creation of child path in VCFFileMerger for GCS 

### DIFF
--- a/src/main/java/org/seqdoop/hadoop_bam/util/VCFFileMerger.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/VCFFileMerger.java
@@ -40,12 +40,11 @@ public class VCFFileMerger {
   public static void mergeParts(final String partDirectory, final String outputFile,
       final VCFHeader header) throws IOException {
     // First, check for the _SUCCESS file.
-    final String successFile = partDirectory + "/_SUCCESS";
-    final Path successPath = asPath(successFile);
-    if (!Files.exists(successPath)) {
-      throw new NoSuchFileException(successFile, null, "Unable to find _SUCCESS file");
-    }
     final Path partPath = asPath(partDirectory);
+    final Path successPath = partPath.resolve("_SUCCESS");
+    if (!Files.exists(successPath)) {
+      throw new NoSuchFileException(successPath.toString(), null, "Unable to find _SUCCESS file");
+    }
     final Path outputPath = asPath(outputFile);
     if (partPath.equals(outputPath)) {
       throw new IllegalArgumentException("Cannot merge parts into output with same " +


### PR DESCRIPTION
This change is needed to allow the merge logic to work on GCS. VCFFileMerger equivalent of #123.