### PR TITLE
Fixes issue in BGZFSplitGuesser relating to incomplete copy.

### DIFF
--- a/src/main/java/org/seqdoop/hadoop_bam/util/BGZFSplitGuesser.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/BGZFSplitGuesser.java
@@ -72,12 +72,15 @@ public class BGZFSplitGuesser {
 		byte[] arr = new byte[2*0xffff - 1];
 
 		this.seekableInFile.seek(beg);
-		int read = inFile.read(arr, 0, Math.min((int) (end - beg),
-				arr.length));
-		if (read == -1) {
-			return -1; // EOF
+		int totalRead = 0;
+		for (int left = Math.min((int)(end - beg), arr.length); left > 0;) {
+			final int r = inFile.read(arr, totalRead, left);
+			if (r < 0)
+				break;
+			totalRead += r;
+			left -= r;
 		}
-		arr = Arrays.copyOf(arr, read);
+		arr = Arrays.copyOf(arr, totalRead);
 
 		this.in = new ByteArraySeekableStream(arr);
 


### PR DESCRIPTION
Supersedes #142. Uses fixed copying logic from `BAMSplitGuesser`. I've done a quick set of tests using BGZFed FASTQs and this seems to be sufficient.

@tomwhite I'd begun looking at extending BaseSplitGuesser, but there's enough of a divergence of the fields between the two classes that this is a non-trivial change.