### PR TITLE
Close all BAM-related I/O resources in BAMRecordReader.

### DIFF
--- a/src/main/java/org/seqdoop/hadoop_bam/BAMRecordReader.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMRecordReader.java
@@ -66,7 +66,8 @@ public class BAMRecordReader
 	private static final Logger logger = LoggerFactory.getLogger(BAMRecordReader.class);
 	private final LongWritable key = new LongWritable();
 	private final SAMRecordWritable record = new SAMRecordWritable();
-
+	private BAMFileReader bamFileReader;
+    
 	private CloseableIterator<SAMRecord> iterator;
 	private boolean reachedEnd;
 	private WrapSeekable<FSDataInputStream> in;
@@ -154,7 +155,7 @@ public class BAMRecordReader
 
 		SamReader.PrimitiveSamReader primitiveSamReader =
 				((SamReader.PrimitiveSamReaderToSamReaderAdapter) samReader).underlyingReader();
-		BAMFileReader bamFileReader = (BAMFileReader) primitiveSamReader;
+		bamFileReader = (BAMFileReader) primitiveSamReader;
 
 		if (logger.isDebugEnabled()) {
 			final long recordStart = virtualStart & 0xffff;
@@ -198,7 +199,9 @@ public class BAMRecordReader
 		return readerFactory.open(resource);
 	}
 
-	@Override public void close() throws IOException { iterator.close(); }
+	@Override public void close() throws IOException {
+		bamFileReader.close();
+        }
 
 	/** Unless the end has been reached, this only takes file position into
 	 * account, not the position within the block.


### PR DESCRIPTION
Resolves #151. Changes the close method to call BAMFileReader.close, which closes the I/O resources related to both the iterator over the BAM file and the BAM file index.