### PR TITLE
In NIOFileUtil.deleteRecursive only delete directory if it exists. 

### DIFF
--- a/src/main/java/org/seqdoop/hadoop_bam/util/NIOFileUtil.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/NIOFileUtil.java
@@ -68,7 +68,7 @@ public class NIOFileUtil {
       }
       @Override
       public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-        Files.delete(dir);
+        Files.deleteIfExists(dir);
         return FileVisitResult.CONTINUE;
       }
     });


### PR DESCRIPTION
Fixes #131.