### PR TITLE
Deprecate BAMRecordWriter constructors that don't take a TaskAttemptC…

### DIFF
--- a/src/main/java/org/seqdoop/hadoop_bam/BAMRecordWriter.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMRecordWriter.java
@@ -88,6 +88,12 @@ public abstract class BAMRecordWriter<K>
 			splittingBAMIndexer = new SplittingBAMIndexer(splittingIndexOutput);
 		}
 	}
+
+	/**
+	 * @deprecated This constructor has no {@link TaskAttemptContext} so it is not
+	 * possible to pass configuration properties to the writer.
+	 */
+	@Deprecated
 	public BAMRecordWriter(
 			OutputStream output, SAMFileHeader header, boolean writeHeader)
 		throws IOException

--- a/src/main/java/org/seqdoop/hadoop_bam/KeyIgnoringBAMRecordWriter.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/KeyIgnoringBAMRecordWriter.java
@@ -48,6 +48,11 @@ public class KeyIgnoringBAMRecordWriter<K> extends BAMRecordWriter<K> {
 	{
 		super(output, header, writeHeader, ctx);
 	}
+	/**
+	 * @deprecated This constructor has no {@link TaskAttemptContext} so it is not
+	 * possible to pass configuration properties to the writer.
+	 */
+	@Deprecated
 	public KeyIgnoringBAMRecordWriter(
 			OutputStream output, SAMFileHeader header, boolean writeHeader)
 		throws IOException


### PR DESCRIPTION
…ontext

since it is not possible to pass configuration properties to the writer.