### PR TITLE
Add options to use the Intel inflater or deflater when reading or

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ below:
 |`BAMInputFormat`|`hadoopbam.bam.bounded-traversal`|`false`|If `true`, only include reads that match the intervals specified in `hadoopbam.bam.intervals`, and unplaced unmapped reads, if `hadoopbam.bam.traverse-unplaced-unmapped` is set to `true`.|
 | |`hadoopbam.bam.intervals`| |Only include reads that match the specified intervals. BAM files must be indexed in this case. Intervals are comma-separated and follow the same syntax as the `-L` option in SAMtools. E.g. `chr1:1-20000,chr2:12000-20000`. When using this option `hadoopbam.bam.bounded-traversal` should be set to `true`.|
 | |`hadoopbam.bam.traverse-unplaced-unmapped`|`false`|If `true`, include unplaced unmapped reads (that is, unmapped reads with no position) When using this option `hadoopbam.bam.bounded-traversal` should be set to `true`.|
+| |`hadoopbam.bam.use-intel-inflater`|`false`|If `true`, use the Intel inflater for decompressing DEFLATE compressed streams. When using this option the [GKL library](https://github.com/Intel-HLS/GKL) must be provided on the classpath.|
 |`KeyIgnoringBAMOutputFormat`|`hadoopbam.bam.write-splitting-bai`|`false`|If `true`, write _.splitting-bai_ files for every BAM file.|
+| |`hadoopbam.bam.use-intel-deflater`|`false`|If `true`, use the Intel deflater for compressing DEFLATE compressed streams. When using this option the [GKL library](https://github.com/Intel-HLS/GKL) must be provided on the classpath.|
 |`CRAMInputFormat`|`hadoopbam.cram.reference-source-path`| |(Required.) The path to the reference. May be an `hdfs://` path.|
 |`FastqInputFormat`|`hbam.fastq-input.base-quality-encoding`|`sanger`|The encoding used for base qualities. One of `sanger` or `illumina`.|
 | |`hbam.fastq-input.filter-failed-qc`|`false`|If `true`, filter out reads that didn't pass quality checks.|

--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,12 @@
             <version>1.0.3</version>
         </dependency>
         <dependency>
+            <groupId>com.intel.gkl</groupId>
+            <artifactId>gkl</artifactId>
+            <version>0.8.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/src/main/java/org/seqdoop/hadoop_bam/BAMInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMInputFormat.java
@@ -111,6 +111,13 @@ public class BAMInputFormat
 	public static final String TRAVERSE_UNPLACED_UNMAPPED_PROPERTY = "hadoopbam.bam.traverse-unplaced-unmapped";
 
 	/**
+	 * If set to true, use the Intel inflater for decompressing DEFLATE compressed streams.
+	 * If set, the <a href="https://github.com/Intel-HLS/GKL">GKL library</a> must be
+	 * provided on the classpath.
+	 */
+	public static final String USE_INTEL_INFLATER_PROPERTY = "hadoopbam.bam.use-intel-inflater";
+
+	/**
 	 * Only include reads that overlap the given intervals. Unplaced unmapped reads are not
 	 * included.
 	 * @param conf the Hadoop configuration to set properties on
@@ -181,6 +188,10 @@ public class BAMInputFormat
 
 	static List<Interval> getIntervals(Configuration conf) {
 		return IntervalUtil.getIntervals(conf, INTERVALS_PROPERTY);
+	}
+
+	static boolean useIntelInflater(Configuration conf) {
+		return conf.getBoolean(USE_INTEL_INFLATER_PROPERTY, false);
 	}
 
 	static Path getIdxPath(Path path) {

--- a/src/main/java/org/seqdoop/hadoop_bam/BAMOutputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMOutputFormat.java
@@ -22,6 +22,7 @@
 
 package org.seqdoop.hadoop_bam;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 
 /** Currently this only locks down the value type of the {@link
@@ -38,4 +39,15 @@ public abstract class BAMOutputFormat<K>
 	 */
 	public static final String WRITE_SPLITTING_BAI =
 			"hadoopbam.bam.write-splitting-bai";
+
+	/**
+	 * If set to true, use the Intel deflater for compressing DEFLATE compressed streams.
+	 * If set, the <a href="https://github.com/Intel-HLS/GKL">GKL library</a> must be
+	 * provided on the classpath.
+	 */
+	public static final String USE_INTEL_DEFLATER_PROPERTY = "hadoopbam.bam.use-intel-deflater";
+
+	static boolean useIntelDeflater(Configuration conf) {
+		return conf.getBoolean(USE_INTEL_DEFLATER_PROPERTY, false);
+	}
 }

--- a/src/main/java/org/seqdoop/hadoop_bam/BAMRecordWriter.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BAMRecordWriter.java
@@ -22,6 +22,7 @@
 
 package org.seqdoop.hadoop_bam;
 
+import htsjdk.samtools.util.BlockCompressedStreamConstants;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
@@ -80,7 +81,7 @@ public abstract class BAMRecordWriter<K>
 	{
 		init(
 			output.getFileSystem(ctx.getConfiguration()).create(output),
-			header, writeHeader);
+			header, writeHeader, BAMOutputFormat.useIntelDeflater(ctx.getConfiguration()));
 		if (ctx.getConfiguration().getBoolean(BAMOutputFormat.WRITE_SPLITTING_BAI, false)) {
 			Path splittingIndex = BAMInputFormat.getIdxPath(output);
 			OutputStream splittingIndexOutput =
@@ -98,15 +99,22 @@ public abstract class BAMRecordWriter<K>
 	{
 		init(
 			output.getFileSystem(ctx.getConfiguration()).create(output),
-			header, writeHeader);
+			header, writeHeader, BAMOutputFormat.useIntelDeflater(ctx.getConfiguration()));
 	}
 	private void init(
-			OutputStream output, SAMFileHeader header, boolean writeHeader)
+			OutputStream output, SAMFileHeader header, boolean writeHeader,
+			boolean useIntelDeflater)
 		throws IOException
 	{
 		origOutput = output;
 
-		compressedOut = new BlockCompressedOutputStream(origOutput, null);
+		if (useIntelDeflater) {
+			compressedOut = new BlockCompressedOutputStream(origOutput, null,
+					BlockCompressedStreamConstants.DEFAULT_COMPRESSION_LEVEL,
+					IntelGKLAccessor.newDeflaterFactory());
+		} else {
+			compressedOut = new BlockCompressedOutputStream(origOutput, null);
+		}
 
 		binaryCodec = new BinaryCodec(compressedOut);
 		recordCodec = new BAMRecordCodec(header);

--- a/src/main/java/org/seqdoop/hadoop_bam/IntelGKLAccessor.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/IntelGKLAccessor.java
@@ -1,0 +1,40 @@
+// Copyright (c) 2017 Aalto University
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+package org.seqdoop.hadoop_bam;
+
+import com.intel.gkl.compression.IntelDeflaterFactory;
+import com.intel.gkl.compression.IntelInflaterFactory;
+import htsjdk.samtools.util.zip.DeflaterFactory;
+import htsjdk.samtools.util.zip.InflaterFactory;
+
+/**
+ * GKL code is kept here so this class is only loaded when the Intel inflator or
+ * deflator is used. This means that users that aren't using these features don't
+ * have to put the GKL JAR on their classpath (since it's a provided dependency).
+ */
+class IntelGKLAccessor {
+  static InflaterFactory newInflatorFactor() {
+    return new IntelInflaterFactory();
+  }
+  static DeflaterFactory newDeflaterFactory() {
+    return new IntelDeflaterFactory();
+  }
+}


### PR DESCRIPTION
writing BAM files. Use of this option requires that you provide
the GKL dependency (https://github.com/Intel-HLS/GKL) on the classpath.