### PR TITLE
Update BGZF block decode logic and refactor BGZFSplitGuesser on BaseSplitGuesser

### DIFF
--- a/src/main/java/org/seqdoop/hadoop_bam/BCFSplitGuesser.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/BCFSplitGuesser.java
@@ -364,6 +364,9 @@ public class BCFSplitGuesser extends BaseSplitGuesser {
 	private short getUByte(final int idx) {
 		return (short)((short)buf.get(idx) & 0xff);
 	}
+	private short getUShort(final int idx) {
+		return (short)(buf.getShort(idx) & 0xffff);
+	}
 
 	public static void main(String[] args) throws IOException {
 		final GenericOptionsParser parser;

--- a/src/main/java/org/seqdoop/hadoop_bam/util/BGZFCodec.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/BGZFCodec.java
@@ -3,6 +3,7 @@ package org.seqdoop.hadoop_bam.util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
@@ -11,6 +12,7 @@ import org.apache.hadoop.io.compress.Decompressor;
 import org.apache.hadoop.io.compress.GzipCodec;
 import org.apache.hadoop.io.compress.SplitCompressionInputStream;
 import org.apache.hadoop.io.compress.SplittableCompressionCodec;
+import org.seqdoop.hadoop_bam.util.WrapSeekable;
 
 /**
  * A Hadoop {@link CompressionCodec} for the
@@ -56,7 +58,7 @@ public class BGZFCodec extends GzipCodec implements SplittableCompressionCodec {
   @Override
   public SplitCompressionInputStream createInputStream(InputStream seekableIn,
       Decompressor decompressor, long start, long end, READ_MODE readMode) throws IOException {
-    BGZFSplitGuesser splitGuesser = new BGZFSplitGuesser(seekableIn);
+      BGZFSplitGuesser splitGuesser = new BGZFSplitGuesser(new WrapSeekable((FSDataInputStream)seekableIn, end, null));
     long adjustedStart = splitGuesser.guessNextBGZFBlockStart(start, end);
     ((Seekable)seekableIn).seek(adjustedStart);
     return new BGZFSplitCompressionInputStream(seekableIn, adjustedStart, end);

--- a/src/main/java/org/seqdoop/hadoop_bam/util/BGZFEnhancedGzipCodec.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/BGZFEnhancedGzipCodec.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.util.BlockCompressedInputStream;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionInputStream;
@@ -11,6 +12,7 @@ import org.apache.hadoop.io.compress.Decompressor;
 import org.apache.hadoop.io.compress.GzipCodec;
 import org.apache.hadoop.io.compress.SplitCompressionInputStream;
 import org.apache.hadoop.io.compress.SplittableCompressionCodec;
+import org.seqdoop.hadoop_bam.util.WrapSeekable;
 
 /**
  * A Hadoop {@link CompressionCodec} for the
@@ -66,7 +68,7 @@ public class BGZFEnhancedGzipCodec extends GzipCodec implements SplittableCompre
         }
       };
     }
-    BGZFSplitGuesser splitGuesser = new BGZFSplitGuesser(seekableIn);
+      BGZFSplitGuesser splitGuesser = new BGZFSplitGuesser(new WrapSeekable((FSDataInputStream)seekableIn, end, null));
     long adjustedStart = splitGuesser.guessNextBGZFBlockStart(start, end);
     ((Seekable)seekableIn).seek(adjustedStart);
     return new BGZFSplitCompressionInputStream(seekableIn, adjustedStart, end);

--- a/src/main/java/org/seqdoop/hadoop_bam/util/BGZFSplitFileInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/BGZFSplitFileInputFormat.java
@@ -36,6 +36,8 @@ import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 
+import org.seqdoop.hadoop_bam.util.WrapSeekable;
+
 /** An {@link org.apache.hadoop.mapreduce.InputFormat} for BGZF-compressed
  * files.
  *
@@ -130,9 +132,7 @@ public abstract class BGZFSplitFileInputFormat<K,V>
 		throws IOException
 	{
 		final Path path = ((FileSplit)splits.get(i)).getPath();
-		final FSDataInputStream in = path.getFileSystem(cfg).open(path);
-
-		final BGZFSplitGuesser guesser = new BGZFSplitGuesser(in);
+		final BGZFSplitGuesser guesser = new BGZFSplitGuesser(WrapSeekable.openPath(cfg, path));
 
 		FileSplit fspl;
 		do {
@@ -149,7 +149,6 @@ public abstract class BGZFSplitFileInputFormat<K,V>
 			++i;
 		} while (i < splits.size() && fspl.getPath().equals(path));
 
-		in.close();
 		return i;
 	}
 

--- a/src/test/java/org/seqdoop/hadoop_bam/TestBGZFSplitGuesser.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestBGZFSplitGuesser.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.seqdoop.hadoop_bam.util.BGZFSplitGuesser;
-
+import org.seqdoop.hadoop_bam.util.WrapSeekable;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
@@ -42,7 +42,7 @@ public class TestBGZFSplitGuesser {
     Configuration conf = new Configuration();
     Path path = new Path(file.toURI());
     FSDataInputStream fsDataInputStream = path.getFileSystem(conf).open(path);
-    BGZFSplitGuesser bgzfSplitGuesser = new BGZFSplitGuesser(fsDataInputStream);
+    BGZFSplitGuesser bgzfSplitGuesser = new BGZFSplitGuesser(WrapSeekable.openPath(conf, path));
     LinkedList<Long> boundaries = new LinkedList<>();
     long start = 1;
     while (true) {


### PR DESCRIPTION
Stems out of work done in #142 and #149. Refactors BGZFSplitGuesser to use the logic in the BaseSplitGuesser class. To do this, we need to make BaseSplitGuesser public. Additionally, we replace the logic that is used in BaseSplitGuesser to identify the start of a BGZF block with logic that doesn't require copying bytes from the input stream to a buffer. This improves the performance of identifying the start of a BGZF block; for whatever reason, that copy to the buffer/methods on the buffer are expensive.

This needs some code style TLC and I'll be back with performance benchmarks.