### PR TITLE
Automatically close input stream in VCFInputFormat after inferring format.

### DIFF
--- a/src/main/java/org/seqdoop/hadoop_bam/VCFInputFormat.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/VCFInputFormat.java
@@ -182,13 +182,14 @@ public class VCFInputFormat
 		if (trustExts) {
 			final VCFFormat f = VCFFormat.inferFromFilePath(path);
 			if (f != null) {
-				formatMap.put(path, f);
+
+			    formatMap.put(path, f);
 				return f;
 			}
 		}
 
-		try {
-			fmt = VCFFormat.inferFromData(path.getFileSystem(conf).open(path));
+		try(InputStream is = path.getFileSystem(conf).open(path)) {
+			fmt = VCFFormat.inferFromData(is);
 		} catch (IOException e) {}
 
 		formatMap.put(path, fmt);


### PR DESCRIPTION
Resolves #184.