### PR TITLE
delete shards as they're merged instead of afterwards

### DIFF
--- a/src/main/java/org/seqdoop/hadoop_bam/util/NIOFileUtil.java
+++ b/src/main/java/org/seqdoop/hadoop_bam/util/NIOFileUtil.java
@@ -98,6 +98,7 @@ public class NIOFileUtil {
 
   /**
    * Merge the given part files in order into an output stream.
+   * This deletes the parts.
    * @param parts the part files to merge
    * @param out the stream to write each file into, in order
    * @throws IOException
@@ -106,8 +107,6 @@ public class NIOFileUtil {
       throws IOException {
     for (final Path part : parts) {
       Files.copy(part, out);
-    }
-    for (final Path part : parts) {
       Files.delete(part);
     }
   }


### PR DESCRIPTION
this should reduce the total amount of scratch disk space that is needed for performing merge operations and should have no effect on performance