### PR TITLE
Improve performance in the Test phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,7 @@
                 <version>2.20.1</version>
                 <configuration>
                   <argLine>-Xms1g -Xmx4g</argLine>
+                	<forkCount>1.5C</forkCount>
                 </configuration>
             </plugin>
             <plugin>
@@ -443,6 +444,7 @@
                         <configuration>
                             <!-- Needed for jacoco data to be written, cf. http://stackoverflow.com/a/25378458/544236 -->
                             <argLine>${argLine}</argLine>
+                	<forkCount>1.5C</forkCount>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
