### PR TITLE
[SECURITY] Fix Temporary File Information Disclosure Vulnerability


### DIFF
--- a/src/test/java/org/seqdoop/hadoop_bam/BAMTestUtil.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/BAMTestUtil.java
@@ -11,6 +11,7 @@ import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 class BAMTestUtil {
   public static File writeBamFile(int numPairs, SAMFileHeader.SortOrder sortOrder)
@@ -42,7 +43,7 @@ class BAMTestUtil {
           ("test-read-%03d-unplaced-unmapped", numPairs++));
     }
 
-    final File bamFile = File.createTempFile("test", ".bam");
+    final File bamFile = Files.createTempFile("test", ".bam").toFile();
     bamFile.deleteOnExit();
     SAMFileHeader samHeader = samRecordSetBuilder.getHeader();
     final SAMFileWriter bamWriter = new SAMFileWriterFactory()
@@ -75,7 +76,7 @@ class BAMTestUtil {
           start2);
     }
 
-    final File bamFile = File.createTempFile("test", ".bam");
+    final File bamFile = Files.createTempFile("test", ".bam").toFile();
     bamFile.deleteOnExit();
     SAMFileHeader samHeader = samRecordSetBuilder.getHeader();
     StringBuffer sb = new StringBuffer();

--- a/src/test/java/org/seqdoop/hadoop_bam/TestBAMOutputFormat.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestBAMOutputFormat.java
@@ -91,7 +91,7 @@ public class TestBAMOutputFormat {
 
     @Test
     public void testBAMRecordWriterNoHeader() throws Exception {
-        final File outFile = File.createTempFile("testBAMWriter", ".bam");
+        final File outFile = Files.createTempFile("testBAMWriter", ".bam").toFile();
         outFile.deleteOnExit();
         final Path outPath = new Path(outFile.toURI());
 
@@ -120,7 +120,7 @@ public class TestBAMOutputFormat {
 
     @Test
     public void testBAMRecordWriterWithHeader() throws Exception {
-        final File outFile = File.createTempFile("testBAMWriter", ".bam");
+        final File outFile = Files.createTempFile("testBAMWriter", ".bam").toFile();
         outFile.deleteOnExit();
         final Path outPath = new Path(outFile.toURI());
 
@@ -150,7 +150,7 @@ public class TestBAMOutputFormat {
     @Test
     public void testBAMOutput() throws Exception {
         final Path outputPath = doMapReduce(testBAMFileName);
-        final File outFile = File.createTempFile("testBAMWriter", ".bam");
+        final File outFile = Files.createTempFile("testBAMWriter", ".bam").toFile();
         outFile.deleteOnExit();
         SAMFileMerger.mergeParts(outputPath.toUri().toString(), outFile.toURI().toString(),
             SAMFormat.BAM, samFileHeader);
@@ -164,7 +164,7 @@ public class TestBAMOutputFormat {
             SAMFileHeader.SortOrder.coordinate).toURI().toString();
         conf.setBoolean(BAMOutputFormat.WRITE_SPLITTING_BAI, true);
         final Path outputPath = doMapReduce(bam);
-        final File outFile = File.createTempFile("testBAMWriter", ".bam");
+        final File outFile = Files.createTempFile("testBAMWriter", ".bam").toFile();
         outFile.deleteOnExit();
         SAMFileMerger.mergeParts(outputPath.toUri().toString(), outFile.toURI().toString(),
             SAMFormat.BAM, new SAMRecordSetBuilder(true, SAMFileHeader.SortOrder.coordinate).getHeader());
@@ -194,7 +194,7 @@ public class TestBAMOutputFormat {
             recordsAtSplits.addAll(getRecordsAtSplits(bamFile, index));
         }
 
-        final File outFile = File.createTempFile("testBAMWriter", ".bam");
+        final File outFile = Files.createTempFile("testBAMWriter", ".bam").toFile();
         //outFile.deleteOnExit();
         SAMFileMerger.mergeParts(outputPath.toUri().toString(), outFile.toURI().toString(),
             SAMFormat.BAM,
@@ -231,7 +231,7 @@ public class TestBAMOutputFormat {
         Path outputPath = doMapReduce(testBAMFileName);
 
         // merge the parts, and write to a temp file
-        final File outFile = File.createTempFile("testBAMWriter", ".bam");
+        final File outFile = Files.createTempFile("testBAMWriter", ".bam").toFile();
         outFile.deleteOnExit();
         SAMFileMerger.mergeParts(outputPath.toUri().toString(), outFile.toURI().toString(),
             SAMFormat.BAM, samFileHeader);

--- a/src/test/java/org/seqdoop/hadoop_bam/TestCRAMOutputFormat.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestCRAMOutputFormat.java
@@ -95,7 +95,7 @@ public class TestCRAMOutputFormat {
 
     @Test
     public void testCRAMRecordWriterNoHeader() throws Exception {
-        final File outFile = File.createTempFile("testCRAMWriter", ".cram");
+        final File outFile = Files.createTempFile("testCRAMWriter", ".cram").toFile();
         outFile.deleteOnExit();
         final Path outPath = new Path(outFile.toURI());
 
@@ -125,7 +125,7 @@ public class TestCRAMOutputFormat {
 
     @Test
     public void testCRAMRecordWriterWithHeader() throws Exception {
-        final File outFile = File.createTempFile("testCRAMWriter", ".cram");
+        final File outFile = Files.createTempFile("testCRAMWriter", ".cram").toFile();
         outFile.deleteOnExit();
         final Path outPath = new Path(outFile.toURI());
 
@@ -155,7 +155,7 @@ public class TestCRAMOutputFormat {
     @Test
     public void testCRAMOutput() throws Exception {
         final Path outputPath = doMapReduce(testCRAMFileName);
-        final File outFile = File.createTempFile("testCRAMWriter", ".cram");
+        final File outFile = Files.createTempFile("testCRAMWriter", ".cram").toFile();
         outFile.deleteOnExit();
         SAMFileMerger.mergeParts(outputPath.toUri().toString(), outFile.toURI().toString(),
             SAMFormat.CRAM, samFileHeader);
@@ -171,7 +171,7 @@ public class TestCRAMOutputFormat {
         Path outputPath = doMapReduce(testCRAMFileName);
 
         // merge the parts, and write to a temp file
-        final File outFile = File.createTempFile("testCRAMWriter", ".cram");
+        final File outFile = Files.createTempFile("testCRAMWriter", ".cram").toFile();
         outFile.deleteOnExit();
         SAMFileMerger.mergeParts(outputPath.toUri().toString(), outFile.toURI().toString(),
             SAMFormat.CRAM, samFileHeader);

--- a/src/test/java/org/seqdoop/hadoop_bam/TestFastqInputFormat.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestFastqInputFormat.java
@@ -27,6 +27,7 @@ import org.seqdoop.hadoop_bam.FastqInputFormat.FastqRecordReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.FileOutputStream;
@@ -137,8 +138,8 @@ public class TestFastqInputFormat
 	@Before
 	public void setup() throws IOException
 	{
-		tempFastq = File.createTempFile("test_fastq_input_format", "fastq");
-		tempGz = File.createTempFile("test_fastq_input_format", ".gz");
+		tempFastq = Files.createTempFile("test_fastq_input_format", "fastq").toFile();
+		tempGz = Files.createTempFile("test_fastq_input_format", ".gz").toFile();
 		conf = new JobConf();
 		key = new Text();
 		fragment = new SequencedFragment();

--- a/src/test/java/org/seqdoop/hadoop_bam/TestQseqInputFormat.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestQseqInputFormat.java
@@ -29,6 +29,7 @@ import org.seqdoop.hadoop_bam.FormatException;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.FileOutputStream;
@@ -92,8 +93,8 @@ public class TestQseqInputFormat
 	@Before
 	public void setup() throws IOException
 	{
-		tempQseq = File.createTempFile("test_qseq_input_format", "qseq");
-		tempGz = File.createTempFile("test_qseq_input_format", ".gz");
+		tempQseq = Files.createTempFile("test_qseq_input_format", "qseq").toFile();
+		tempGz = Files.createTempFile("test_qseq_input_format", ".gz").toFile();
 		conf = new JobConf();
 		key = new Text();
 		fragment = new SequencedFragment();

--- a/src/test/java/org/seqdoop/hadoop_bam/TestVCFOutputFormat.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestVCFOutputFormat.java
@@ -22,6 +22,7 @@ package org.seqdoop.hadoop_bam;
 
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
 import java.util.*;
 
 import htsjdk.samtools.seekablestream.SeekableFileStream;
@@ -54,7 +55,7 @@ public class TestVCFOutputFormat {
 
     @Before
     public void setup() throws IOException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
-        test_vcf_output = File.createTempFile("test_vcf_output", "");
+        test_vcf_output = Files.createTempFile("test_vcf_output", "").toFile();
         test_vcf_output.delete();
         writable = new VariantContextWritable();
         Configuration conf = new Configuration();

--- a/src/test/java/org/seqdoop/hadoop_bam/TestVCFRoundTrip.java
+++ b/src/test/java/org/seqdoop/hadoop_bam/TestVCFRoundTrip.java
@@ -32,6 +32,7 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -199,8 +200,7 @@ public class TestVCFRoundTrip {
         // merge the output
         VCFHeader vcfHeader = VCFHeaderReader.readHeaderFrom(new SeekableFileStream(new
             File(testVCFFileName)));
-        final File outFile = File.createTempFile("testVCFWriter",
-            testVCFFileName.substring(testVCFFileName.lastIndexOf(".")));
+        final File outFile = Files.createTempFile("testVCFWriter", testVCFFileName.substring(testVCFFileName.lastIndexOf("."))).toFile();
         outFile.deleteOnExit();
         VCFFileMerger.mergeParts(outputPath.toUri().toString(), outFile.toURI().toString(),
             vcfHeader);
@@ -256,7 +256,7 @@ public class TestVCFRoundTrip {
         File actualVcf;
         // work around TribbleIndexedFeatureReader not reading header from .bgz files
         if (vcf.getName().endsWith(".bgz")) {
-            actualVcf = File.createTempFile(vcf.getName(), ".gz");
+            actualVcf = Files.createTempFile(vcf.getName(), ".gz").toFile();
             actualVcf.deleteOnExit();
             Files.copy(vcf, actualVcf);
         } else {


### PR DESCRIPTION

# Security Vulnerability Fix

This pull request fixes a Temporary File Information Disclosure Vulnerability, which existed in this project.

## Preamble

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file posix permissions are set.

This PR was generated because a call to `File.createTempFile(..)` was detected in this repository in a way that makes this project vulnerable to local information disclosure.
With the default uname configuration, `File.createTempFile(..)` creates a file with the permissions `-rw-r--r--`. This means that any other user on the system can read the contents of this file.

### Impact

Information in this file is visible to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files.

#### Other Examples

 - [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit
 - [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen
 - [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty
 - [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

# The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempFile("temp dir").toFile();
```

The API both creates the file securely, ie. with a random, non-conflicting name, with file permissions that only allow the currently executing user to read or write the contents of this file.
By default, `Files.createTempFile("temp dir")` will create a file with the permissions `-rw-------`, which only allows the user that created the file to view/write the file contents.

# :arrow_right: Vulnerability Disclosure :arrow_left:

:wave: Vulnerability disclosure is a super important part of the vulnerability handling process and should not be skipped! This may be completely new to you, and that's okay, I'm here to assist!

First question, do we need to perform vulnerability disclosure? It depends!

 1. Is the vulnerable code only in tests or example code? No disclosure required!
 2. Is the vulnerable code in code shipped to your end users? Vulnerability disclosure is probably required!

## Vulnerability Disclosure How-To

You have a few options options to perform vulnerability disclosure. However, I'd like to suggest the following 2 options:

 1. Request a CVE number from GitHub by creating a repository-level [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/creating-a-repository-security-advisory). This has the advantage that, if you provide sufficient information, GitHub will automatically generate Dependabot alerts for your downstream consumers, resolving this vulnerability more quickly.
 2. Reach out to the team at Snyk to assist with CVE issuance. They can be reached at the [Snyk's Disclosure Email](mailto:report@snyk.io).

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's CodeQL using this [CodeQL Query](https://codeql.github.com/codeql-query-help/java/java-local-temp-file-or-directory-information-disclosure/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher.

## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly hand crafted to bring this security fix to your repository.

The source code that generated this PR can be found here:
[SecureTempFileCreation](https://github.com/openrewrite/rewrite-java-security/blob/main/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Sponsorship & Support

This contribution is sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This PR was generated by [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.

## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/18
